### PR TITLE
fix: migrate to Pydantic v2 patterns and fix test warnings

### DIFF
--- a/amplifier/slides_tool/models.py
+++ b/amplifier/slides_tool/models.py
@@ -10,7 +10,9 @@ from typing import Any
 from typing import Literal
 
 from pydantic import BaseModel
+from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_serializer
 
 
 class Slide(BaseModel):
@@ -28,6 +30,8 @@ class Slide(BaseModel):
 class Presentation(BaseModel):
     """Complete presentation data structure."""
 
+    model_config = ConfigDict()
+
     title: str = Field(description="Presentation title")
     subtitle: str | None = Field(None, description="Presentation subtitle")
     author: str | None = Field(None, description="Author name")
@@ -37,8 +41,10 @@ class Presentation(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
     version: int = Field(1, description="Version number for tracking revisions")
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
+    @field_serializer("date")
+    def serialize_date(self, date: datetime | None, _info):
+        """Serialize datetime to ISO format."""
+        return date.isoformat() if date else None
 
 
 class GenerationRequest(BaseModel):

--- a/amplifier/slides_tool/review/models.py
+++ b/amplifier/slides_tool/review/models.py
@@ -9,7 +9,9 @@ from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel
+from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_serializer
 
 
 class SlideIssue(BaseModel):
@@ -28,6 +30,8 @@ class SlideIssue(BaseModel):
 class ReviewResult(BaseModel):
     """Result of a presentation review analysis."""
 
+    model_config = ConfigDict()
+
     overall_score: float = Field(ge=0, le=10, description="Overall quality score (0-10)")
     issues: list[SlideIssue] = Field(default_factory=list, description="List of issues found")
     strengths: list[str] = Field(default_factory=list, description="Positive aspects of the presentation")
@@ -35,8 +39,10 @@ class ReviewResult(BaseModel):
     needs_revision: bool = Field(description="Whether the presentation needs revision")
     timestamp: datetime = Field(default_factory=datetime.now, description="When the review was conducted")
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
+    @field_serializer("timestamp")
+    def serialize_timestamp(self, timestamp: datetime, _info):
+        """Serialize datetime to ISO format."""
+        return timestamp.isoformat()
 
     def get_critical_issues(self) -> list[SlideIssue]:
         """Get only critical issues."""
@@ -92,6 +98,8 @@ class ReviewRequest(BaseModel):
 class RevisionIteration(BaseModel):
     """Represents one iteration of the revision process."""
 
+    model_config = ConfigDict()
+
     iteration: int = Field(description="Iteration number (1-based)")
     review_result: ReviewResult = Field(description="Review result for this iteration")
     revision_applied: bool = Field(description="Whether a revision was applied")
@@ -99,8 +107,10 @@ class RevisionIteration(BaseModel):
     improvement_delta: float | None = Field(None, description="Score improvement from previous iteration")
     timestamp: datetime = Field(default_factory=datetime.now, description="When this iteration was completed")
 
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
+    @field_serializer("timestamp")
+    def serialize_timestamp(self, timestamp: datetime, _info):
+        """Serialize datetime to ISO format."""
+        return timestamp.isoformat()
 
 
 class AutoImproveRequest(BaseModel):

--- a/tests/test_parallel_execution.py
+++ b/tests/test_parallel_execution.py
@@ -136,12 +136,9 @@ def test_parallelism_detection():
 
     print("\n" + "=" * 50)
 
-    # Return test results
-    return {
-        "sequential_test": seq_analysis["pattern"] == "sequential",
-        "parallel_test": par_analysis["pattern"] == "parallel",
-        "should_fail_initially": seq_analysis["pattern"] == "sequential",
-    }
+    # Verify test results with assertions
+    assert seq_analysis["pattern"] == "sequential", "Sequential pattern should be detected as sequential"
+    assert par_analysis["pattern"] == "parallel", "Parallel pattern should be detected as parallel"
 
 
 def demonstrate_parallelizable_tasks():
@@ -189,14 +186,11 @@ def demonstrate_parallelizable_tasks():
 
 if __name__ == "__main__":
     # Run detection test
-    results = test_parallelism_detection()
+    test_parallelism_detection()
 
     # Show parallelizable examples
     demonstrate_parallelizable_tasks()
 
     # Summary
     print("\nTest Summary:")
-    if results["should_fail_initially"]:
-        print("✗ Test correctly shows SEQUENTIAL execution (needs parallel guidance)")
-    else:
-        print("✓ Test shows PARALLEL execution (guidance is working)")
+    print("✓ Tests completed - check output above for results")


### PR DESCRIPTION
- Replace deprecated class Config with ConfigDict in Pydantic models
- Replace json_encoders with @field_serializer for datetime serialization
- Fix pytest warning by removing test function return value in favor of assertions
- Update test_parallel_execution.py to use assertions instead of returning dict

This eliminates all 7 warnings that were appearing during test runs:
- 3 PydanticDeprecatedSince20 warnings for class-based config
- 3 PydanticDeprecatedSince20 warnings for json_encoders
- 1 PytestReturnNotNoneWarning for test function return value

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>