### PR TITLE
refactor: move subagent logs from .data/ to logs/ directory

### DIFF
--- a/.claude/tools/subagent-logger.py
+++ b/.claude/tools/subagent-logger.py
@@ -17,13 +17,9 @@ except ImportError:
 
 def ensure_log_directory() -> Path:
     """Ensure the log directory exists and return its path."""
-    if paths is not None:
-        # Use centralized path configuration
-        log_dir = paths.data_dir / "subagent-logs"
-    else:
-        # Fall back to legacy .data directory
-        project_root = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
-        log_dir = project_root / ".data" / "subagent-logs"
+    # Use logs directory in project root (gitignored but project-local)
+    project_root = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    log_dir = project_root / "logs" / "subagent-logs"
 
     log_dir.mkdir(parents=True, exist_ok=True)
     return log_dir


### PR DESCRIPTION
Relocate subagent log files from `.data/subagent-logs/` to `logs/subagent-logs/`
for better separation of concerns. The logs directory is already gitignored and
provides a more appropriate location for project-specific logging, keeping it
separate from other data storage needs.

- Remove centralized path configuration logic that was unused
- Simplify implementation to always use project root's logs directory
- Tested with actual subagent invocations to verify correct logging