### PR TITLE
refactor: remove redundant content-scan from knowledge pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,15 +253,12 @@ knowledge-export: ## Export all knowledge as JSON or text. Usage: make knowledge
 	uv run python -m amplifier.knowledge_synthesis.cli export --format $$format
 
 # Knowledge Pipeline Commands
-knowledge-update: ## Full pipeline: scan content + extract knowledge + synthesize patterns
+knowledge-update: ## Full pipeline: extract knowledge + synthesize patterns
 	@echo "🚀 Running full knowledge pipeline..."
-	@echo "Step 1: Scanning content directories..."
-	@$(MAKE) --no-print-directory content-scan
-	@echo ""
-	@echo "Step 3: Extracting knowledge..."
+	@echo "Step 1: Extracting knowledge..."
 	@$(MAKE) --no-print-directory knowledge-sync
 	@echo ""
-	@echo "Step 4: Synthesizing patterns..."
+	@echo "Step 2: Synthesizing patterns..."
 	@$(MAKE) --no-print-directory knowledge-synthesize
 	@echo ""
 	@echo "✅ Knowledge pipeline complete!"

--- a/amplifier/content_loader/loader.py
+++ b/amplifier/content_loader/loader.py
@@ -125,8 +125,11 @@ class ContentLoader:
             logger.warning(f"Failed to load {file_path}: {e}")
             return None
 
-    def load_all(self) -> Iterator[ContentItem]:
+    def load_all(self, quiet: bool = False) -> Iterator[ContentItem]:
         """Load all content from configured directories.
+
+        Args:
+            quiet: If True, suppress progress output to stdout.
 
         Yields ContentItem objects for each successfully loaded file.
         Skips files that cannot be loaded and logs warnings.
@@ -154,7 +157,7 @@ class ContentLoader:
                 total_files_found += 1
 
                 # Update progress during scanning
-                if dir_files_found % 10 == 0:  # Update every 10 files
+                if not quiet and dir_files_found % 10 == 0:  # Update every 10 files
                     sys.stdout.write(f"\rScanning: {total_files_found} files found...")
                     sys.stdout.flush()
 
@@ -164,7 +167,7 @@ class ContentLoader:
                     yield item
 
             # Clear the progress line
-            if dir_files_found > 0:
+            if not quiet and dir_files_found > 0:
                 sys.stdout.write(
                     f"\rScanned {content_dir}: {dir_files_found} files found, {total_files_loaded} loaded\n"
                 )

--- a/amplifier/knowledge_synthesis/cli.py
+++ b/amplifier/knowledge_synthesis/cli.py
@@ -78,8 +78,8 @@ async def _sync_content(max_items: int | None):
     emitter = EventEmitter()
     loader = ContentLoader()
 
-    # Load all content items
-    content_items = list(loader.load_all())
+    # Load all content items (quiet mode to suppress progress output)
+    content_items = list(loader.load_all(quiet=True))
 
     if not content_items:
         logger.info("No content files found in configured directories.")
@@ -232,8 +232,8 @@ async def _sync_content_resilient(max_items: int | None, retry_partial: bool = F
     loader = ContentLoader()
     emitter = EventEmitter()
 
-    # Load all content items
-    content_items = list(loader.load_all())
+    # Load all content items (quiet mode to suppress progress output)
+    content_items = list(loader.load_all(quiet=True))
 
     if not content_items:
         logger.info("No content files found in configured directories.")


### PR DESCRIPTION
The content-scan step was completely redundant in the knowledge-update pipeline:
- Both content-scan and knowledge-sync independently call ContentLoader.load_all()
- No state, cache, or side effects were created by content-scan
- The noisy output broke the refined observability of the pipeline

Changes:
- Remove content-scan from knowledge-update pipeline (2 steps instead of 3)
- Add quiet mode to ContentLoader to suppress progress output in pipelines
- Update knowledge-sync to use quiet mode for cleaner output
- Keep content-scan available as standalone diagnostic tool

This follows the ruthless simplicity philosophy - removing what adds no value
while preserving the refined observability patterns established in the pipeline.

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>