### PR TITLE
fix: ContentLoader now uses PathConfig to properly load .env settings

### DIFF
--- a/amplifier/content_loader/loader.py
+++ b/amplifier/content_loader/loader.py
@@ -3,7 +3,6 @@
 import hashlib
 import json
 import logging
-import os
 import re
 from collections.abc import Iterator
 from pathlib import Path
@@ -37,13 +36,15 @@ class ContentLoader:
 
         Args:
             content_dirs: Optional list of directories to scan.
-                         If None, uses AMPLIFIER_CONTENT_DIRS env var.
+                         If None, uses PathConfig to get configured directories.
         """
         if content_dirs is None:
-            env_dirs = os.environ.get("AMPLIFIER_CONTENT_DIRS", "")
-            content_dirs = [d.strip() for d in env_dirs.split(",") if d.strip()]
+            # Use PathConfig which properly loads from .env file
+            from amplifier.config.paths import paths
 
-        self.content_dirs = [Path(d).resolve() for d in content_dirs if Path(d).exists()]
+            self.content_dirs = [p for p in paths.content_dirs if p.exists()]
+        else:
+            self.content_dirs = [Path(d).resolve() for d in content_dirs if Path(d).exists()]
 
         if not self.content_dirs:
             logger.warning("No valid content directories configured")


### PR DESCRIPTION
ContentLoader was directly reading from os.environ without loading the .env file, causing AMPLIFIER_CONTENT_DIRS to be ignored. Now it uses PathConfig which properly loads environment variables from .env file.

This fixes the issue where 'make knowledge-update' wasn't finding content even when AMPLIFIER_CONTENT_DIRS was set in .env.

*NOTE* KNOWLEDGE_MINING_STORAGE_DIR in the .env appears to be an unused env var. There does not seem to be a way to set my knowldge extraction to be in a different location than AMPLIFIER_DATA_DIR. That may be fine. I was looking to have my content and extracted knowledge in one place outside of the repo, but leave the rest in as more temporary .gitignored stuff I might not care about keeping.