### PR TITLE
dev environment: cache and shell

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -76,7 +76,7 @@
     // for workspaces.
     // Ensure the cache is on the same disk for optimal uv performance. https://docs.astral.sh/uv/concepts/cache/#cache-directory
     // ${containerWorkspaceFolder} == /workspaces/repo-name
-    "UV_CACHE_DIR": "${containerWorkspaceFolder}/../.cache/uv"
+    "UV_CACHE_DIR": "${containerWorkspaceFolder}/.cache/uv"
   }
   // Connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -15,6 +15,17 @@ git config --global push.autoSetupRemote true
 echo "    ✅ Git configured"
 
 echo ""
+echo "🔧  Setting up pnpm global bin directory..."
+# Ensure SHELL is set for pnpm setup
+export SHELL="${SHELL:-/bin/bash}"
+# Configure pnpm to use a global bin directory
+pnpm setup 2>&1 | grep -v "^$" || true
+# Export for current session (will also be in ~/.bashrc for future sessions)
+export PNPM_HOME="/home/vscode/.local/share/pnpm"
+export PATH="$PNPM_HOME:$PATH"
+echo "    ✅ pnpm configured"
+
+echo ""
 echo "========================================="
 echo "✅  Post-create tasks complete at $(date)"
 echo "========================================="

--- a/tools/makefiles/recursive.mk
+++ b/tools/makefiles/recursive.mk
@@ -38,7 +38,11 @@ MAKE_FILES = $(shell dir Makefile /b /s)
 ALL_MAKE_DIRS = $(sort $(filter-out $(subst /,\,$(abspath ./)),$(patsubst %\,%,$(dir $(MAKE_FILES)))))
 endif
 
-MAKE_DIRS := $(call FILTER_OUT,site-packages,$(call FILTER_OUT,node_modules,$(ALL_MAKE_DIRS)))
+# Filter out dependency and cache directories from recursive make targets
+MAKE_DIRS_TMP := $(ALL_MAKE_DIRS)
+MAKE_DIRS_TMP := $(call FILTER_OUT,node_modules,$(MAKE_DIRS_TMP))
+MAKE_DIRS_TMP := $(call FILTER_OUT,site-packages,$(MAKE_DIRS_TMP))
+MAKE_DIRS := $(call FILTER_OUT,.cache,$(MAKE_DIRS_TMP))
 
 .PHONY: .clean-error-log .print-error-log
 


### PR DESCRIPTION
The recursive Makefile was discovering and trying to run make in ALL subdirectories containing Makefiles, including dependency package sources downloaded by UV into .cache/uv/.

When UV downloaded the temporalio package, its source contained Makefiles that expected Go tooling, causing make install to fail.

Added .cache to the FILTER_OUT list alongside node_modules and site-packages to prevent the recursive Makefile from entering cache directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fix: correct UV_CACHE_DIR to use project directory

The UV_CACHE_DIR was configured to create cache at /workspaces/.cache/uv, but the vscode user lacks permission to create directories in /workspaces (owned by root).

Changed from:
  "${containerWorkspaceFolder}/../.cache/uv"

To:
  "${containerWorkspaceFolder}/.cache/uv"

This creates the cache inside the project directory where the vscode user has write permissions, while maintaining the performance benefit of having the cache on the same disk as the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fix: Set SHELL environment variable for pnpm setup in DevContainer

The pnpm setup command requires SHELL to be set to determine which shell configuration file to modify. During DevContainer post-create execution, SHELL is not automatically set, causing pnpm setup to fail silently with ERR_PNPM_UNKNOWN_SHELL.

Changes:
- Explicitly set SHELL=/bin/bash before running pnpm setup
- Updated DISCOVERIES.md with detailed root cause analysis
- Documented the silent failure issue and log checking

This ensures pnpm is properly configured on fresh DevContainer builds, making `make install` work immediately without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)