### PR TITLE
Update list of folders ignored by python builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ exclude = [
     "dist/**",
     ".data/**",
     "ai_working/**",
-    "workspace/**",
 ]
 typeCheckingMode = "basic"
 reportMissingImports = false


### PR DESCRIPTION
- ignore "node_modules" everywhere
- ignore custom projects developed under the “workspace” directory