### PR TITLE
Add AWS Bedrock provider module to community catalog

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -207,15 +207,10 @@ Built something cool? Share it with the community!
 
 ### Community-Contributed Modules
 
-*No community modules yet - be the first to contribute!*
-
-**Example entry format:**
-```markdown
-- **tool-git** by @username - Git operations and repository management
-  - Repository: https://github.com/username/amplifier-module-tool-git
+- **provider-bedrock** by @brycecutt-msft - AWS Bedrock integration with cross-region inference support for Claude models
+  - Repository: https://github.com/brycecutt-msft/amplifier-module-provider-bedrock
   - Compatible: Amplifier 0.1.x
   - Status: Active
-```
 
 ---
 


### PR DESCRIPTION
## Summary
Adds the AWS Bedrock provider module to the community modules catalog.

## Module Details
- **Module**: provider-bedrock
- **Author**: @brycecutt-msft
- **Repository**: https://github.com/brycecutt-msft/amplifier-module-provider-bedrock
- **Description**: AWS Bedrock integration with cross-region inference support for Claude models
- **Compatible**: Amplifier 0.1.x

## Features
- Claude 4 series model support via AWS Bedrock
- Cross-region inference with automatic routing
- AWS SSO/IAM authentication
- Tool calling and streaming support
- Message validation

## Checklist
- [x] Module follows Amplifier conventions
- [x] Includes comprehensive README
- [x] Includes tests
- [x] Specifies compatible Amplifier versions
- [x] Source code publicly available