### PR TITLE
Add amplifier-playground to community applications

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -194,6 +194,7 @@ Applications built by the community using Amplifier.
 | **app-blog-creator** | AI-powered blog creation with style-aware generation and rich markdown editor (web interface designed with design-intelligence collection, uses image-generation, style-extraction, and markdown-utils modules) | @robotdad | [amplifier-app-blog-creator](https://github.com/robotdad/amplifier-app-blog-creator) | Amplifier 0.1.x | Active |
 | **app-voice** | Desktop voice assistant with native speech-to-speech via OpenAI Realtime API (uses provider-openai-realtime) | @robotdad | [amplifier-app-voice](https://github.com/robotdad/amplifier-app-voice) | Amplifier 0.1.x | Experimental |
 | **amplifier-app-tool-generator** | AI-powered tool generator for creating custom Amplifier tools | @samueljklee | [amplifier-app-tool-generator](https://github.com/samueljklee/amplifier-app-tool-generator) | Amplifier@next | Active |
+| **amplifier-playground** | Interactive environment for building, configuring, and testing Amplifier AI agent sessions with web UI and CLI | @samueljklee | [amplifier-playground](https://github.com/samueljklee/amplifier-playground) | Amplifier@next | Active |
 
 **Want to showcase your application?** Submit a PR to add your Amplifier-powered application to this list!
 


### PR DESCRIPTION
## Summary
- Adds amplifier-playground to the Community Applications section in MODULES.md
- Interactive environment for building, configuring, and testing Amplifier AI agent sessions with web UI and CLI

## Test plan
- [ ] Verify link to repository works
- [ ] Verify table formatting renders correctly

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)