### PR TITLE
Add desktop streaming modules to community catalog

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -295,6 +295,16 @@ Built something cool? Share it with the community!
   - Compatible: Amplifier 0.1.x
   - Status: Experimental
 
+- **hooks-event-broadcast** by @microsoftmj - Transport-agnostic event broadcasting hook for streaming UI applications (uses capability injection pattern)
+  - Repository: https://github.com/microsoft/amplifier-module-hooks-event-broadcast
+  - Compatible: Amplifier 0.1.x
+  - Status: Experimental
+
+- **tool-memory** by @microsoftmj - Persistent memory tool for storing and retrieving facts across sessions
+  - Repository: https://github.com/microsoft/amplifier-module-tool-memory
+  - Compatible: Amplifier 0.1.x
+  - Status: Experimental
+
 ---
 
 ## Building Your Own Modules


### PR DESCRIPTION
## Summary
Adds two community modules used by Amplifier Desktop for streaming UI applications.

### Modules Added

**hooks-event-broadcast**
- Transport-agnostic event broadcasting hook
- Uses capability injection pattern (module doesn't know about WebSocket/SSE)
- Relays kernel events to registered transports for real-time UI updates

**tool-memory**  
- Persistent memory tool for storing facts across sessions
- SQLite-backed storage
- Supports categories and search

### Use Case
These modules enable applications to build streaming interfaces on top of Amplifier. The Amplifier Desktop app uses both for its real-time chat UI with persistent memory.

### Compliance
- Both follow ecosystem patterns per BUNDLE_GUIDE.md
- Use capability injection (no transport knowledge in modules)
- Available at microsoft/amplifier-module-* repos

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>