### PR TITLE
docs: add desktop community modules + bundle

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -291,6 +291,27 @@ Built something cool? Share it with the community!
   - Compatible: Amplifier 0.1.x
   - Status: Experimental
 
+
+- **tool-memory** by @michaeljabbour - Persistent memory across sessions backed by SQLite
+  - Repository: https://github.com/michaeljabbour/amplifier-module-tool-memory
+  - Compatible: Amplifier 0.1.x
+  - Status: Active
+
+- **hooks-event-broadcast** by @michaeljabbour - Transport-agnostic event broadcast (e.g. WebSocket/SSE) for streaming UIs
+  - Repository: https://github.com/michaeljabbour/amplifier-module-hooks-event-broadcast
+  - Compatible: Amplifier 0.1.x
+  - Status: Active
+
+### Community-Contributed Bundles
+
+Bundles are composable configuration layers (not Python packages). See https://github.com/microsoft/amplifier-foundation/blob/main/docs/BUNDLE_GUIDE.md.
+
+- **amplifier-desktop** by @michaeljabbour - Desktop app bundle composing foundation with streaming UI + persistent memory
+  - Repository: https://github.com/michaeljabbour/amplifier-desktop
+  - Bundle: https://github.com/michaeljabbour/amplifier-desktop/blob/main/sidecar/bundle.yaml
+  - Compatible: Amplifier 0.1.x
+  - Status: Active
+
 ---
 
 ## Building Your Own Modules


### PR DESCRIPTION
Adds the desktop-related community contributions in the canonical catalog (per docs/REPOSITORY_RULES.md and reviewer guidance):

- `tool-memory` (SQLite-backed persistent memory)
- `hooks-event-broadcast` (transport-agnostic event broadcast for streaming UIs)
- Desktop bundle reference (composed on top of amplifier-foundation)

Context:
- microsoft/amplifier-core#4 (MODULES.md) was closed in favor of updating this file
- microsoft/amplifier-foundation#2 (desktop bundle) was closed; bundle should live in the app / as a community bundle reference
