### PR TITLE
docs(MODULES.md): add hooks-ui-bridge community module

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -231,6 +231,7 @@ Modules built by the community.
 | Module | Description | Author | Repository |
 |--------|-------------|--------|------------|
 | **hooks-event-broadcast** | Transport-agnostic event broadcasting for streaming UI applications | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-module-hooks-event-broadcast](https://github.com/michaeljabbour/amplifier-module-hooks-event-broadcast) |
+| **hooks-ui-bridge** | Universal event bridge for any UI system (Textual, Tauri, Web, VS Code) | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-module-hooks-ui-bridge](https://github.com/michaeljabbour/amplifier-module-hooks-ui-bridge) |
 
 ### Contributing Your Modules
 


### PR DESCRIPTION
## Summary

Adds hooks-ui-bridge to the community modules catalog.

## Module Description

Universal event bridge that transforms Amplifier events to JSON-serializable UIEvents for consumption by any UI framework:

- **Textual TUI** - asyncio.Queue adapter for Python TUIs
- **Tauri Desktop/Mobile** - stdin/stdout JSON lines for sidecar architecture
- **WebSocket** - Real-time streaming for web dashboards
- **VS Code Extension** - stdio adapter

## Features

- Three customization levels (config → handlers → adapters)
- Event correlation (start/end events)
- Bidirectional commands (UI → Amplifier)
- Deep config merging for nested settings
- Event history and replay support

## Checklist

- [x] Follows Amplifier module conventions
- [x] Comprehensive README
- [x] Includes tests (45 passing)
- [x] Only depends on amplifier-core
- [x] Source code publicly available