### PR TITLE
docs: Add lsp-typescript bundle to MODULES.md catalog

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -51,6 +51,7 @@ Composable configuration packages that combine providers, behaviors, agents, and
 | **design-intelligence** | Comprehensive design intelligence with 7 specialized agents, design philosophy framework, and knowledge base | [amplifier-bundle-design-intelligence](https://github.com/microsoft/amplifier-bundle-design-intelligence) |
 | **lsp** | Core Language Server Protocol support for code intelligence operations | [amplifier-bundle-lsp](https://github.com/microsoft/amplifier-bundle-lsp) |
 | **lsp-python** | Python code intelligence via Pyright language server (extends lsp bundle) | [amplifier-bundle-lsp-python](https://github.com/microsoft/amplifier-bundle-lsp-python) |
+| **lsp-typescript** | TypeScript/JavaScript code intelligence via typescript-language-server (extends lsp bundle) | [amplifier-bundle-lsp-typescript](https://github.com/microsoft/amplifier-bundle-lsp-typescript) |
 
 **Usage**: Bundles are loaded via the `amplifier bundle` commands:
 


### PR DESCRIPTION
## Summary
- Added lsp-typescript bundle entry to the Bundles section in docs/MODULES.md
- Entry includes description and link to the bundle repository
- Positioned after lsp-python for logical grouping

## Test plan
- [x] Verified MODULES.md formatting is correct
- [x] Confirmed link to amplifier-bundle-lsp-typescript repository
- [x] Entry follows existing table format and style

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>