### PR TITLE
docs: Add shadow bundle to ecosystem catalog

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -52,6 +52,7 @@ Composable configuration packages that combine providers, behaviors, agents, and
 | **lsp** | Core Language Server Protocol support for code intelligence operations | [amplifier-bundle-lsp](https://github.com/microsoft/amplifier-bundle-lsp) |
 | **lsp-python** | Python code intelligence via Pyright language server (extends lsp bundle) | [amplifier-bundle-lsp-python](https://github.com/microsoft/amplifier-bundle-lsp-python) |
 | **lsp-typescript** | TypeScript/JavaScript code intelligence via typescript-language-server (extends lsp bundle) | [amplifier-bundle-lsp-typescript](https://github.com/microsoft/amplifier-bundle-lsp-typescript) |
+| **shadow** | OS-level sandboxed environments for testing local Amplifier ecosystem changes safely | [amplifier-bundle-shadow](https://github.com/microsoft/amplifier-bundle-shadow) |
 
 **Usage**: Bundles are loaded via the `amplifier bundle` commands:
 


### PR DESCRIPTION
## Summary
- Added the shadow bundle entry to the Bundles table in MODULES.md so it's discoverable

## Test plan
- [x] Verified markdown table formatting is correct
- [x] Links to correct GitHub repository

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>