### PR TITLE
feat: add Community Bundles section to MODULES.md

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -206,6 +206,20 @@ Applications built by the community using Amplifier.
 
 ---
 
+## Community Bundles
+
+Bundles built by the community.
+
+> **SECURITY WARNING**: Community bundles execute arbitrary code in your environment with full access to your filesystem, network, and credentials. Only use bundles from sources you trust. Review code before installation.
+
+| Bundle | Description | Author | Repository |
+|--------|-------------|--------|------------|
+| **expert-cookbook** | Achieve the State of the Art with Microsoft Amplifier | [@DavidKoleczek](https://github.com/DavidKoleczek) | [amplifier-expert-cookbook](https://github.com/DavidKoleczek/amplifier-expert-cookbook) |
+
+**Want to share your bundle?** Submit a PR to add your Amplifier bundle to this list!
+
+---
+
 ## Community Modules
 
 Modules built by the community.


### PR DESCRIPTION
## Summary

- Add new **Community Bundles** section to the component catalog
- Place it between Community Applications and Community Modules for logical organization
- Include security warning consistent with other community sections
- Add first entry: [expert-cookbook](https://github.com/DavidKoleczek/amplifier-expert-cookbook) bundle

## Details

The MODULES.md catalog previously had sections for Community Applications and Community Modules, but no section for Community Bundles. This PR adds that missing section to allow community contributors to share their bundles.

## Test plan

- [x] Verify markdown renders correctly
- [x] Verify table formatting matches existing sections
- [x] Verify links are valid

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>