### PR TITLE
docs: add community bundle memory to MODULES.md

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -216,6 +216,7 @@ Bundles built by the community.
 | Bundle | Description | Author | Repository |
 |--------|-------------|--------|------------|
 | **expert-cookbook** | Achieve the State of the Art with Microsoft Amplifier | [@DavidKoleczek](https://github.com/DavidKoleczek) | [amplifier-expert-cookbook](https://github.com/DavidKoleczek/amplifier-expert-cookbook) |
+| **memory** | Persistent memory system with automatic capture, progressive disclosure context injection, and event broadcasting | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-bundle-memory](https://github.com/michaeljabbour/amplifier-bundle-memory) |
 
 **Want to share your bundle?** Submit a PR to add your Amplifier bundle to this list!
 


### PR DESCRIPTION
## Summary

Adds the `amplifier-bundle-memory` community bundle to the component catalog.

## Bundle Overview

**Repository**: https://github.com/michaeljabbour/amplifier-bundle-memory

Persistent memory system for AI agents that provides:
- **Automatic capture** via hooks-memory-capture
- **Progressive disclosure** context injection via context-memory
- **Event broadcasting** for real-time UI updates
- **Memory curation** agent for organization and maintenance

### Modules Included
- tool-memory (SQLite + FTS5 storage)
- context-memory (token-budgeted context injection)
- hooks-memory-capture (automatic observation capture)
- hooks-event-broadcast (transport-agnostic events)

### Installation
```bash
amplifier bundle add git+https://github.com/michaeljabbour/amplifier-bundle-memory@main
```