### PR TITLE
docs: add amplifier-module-deepresearch to community modules

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -244,6 +244,7 @@ Modules built by the community.
 | **module-image-generation** | Multi-provider AI image generation with DALL-E, Imagen, and GPT-Image-1 | [@robotdad](https://github.com/robotdad) | [amplifier-module-image-generation](https://github.com/robotdad/amplifier-module-image-generation) |
 | **module-style-extraction** | Extract and apply writing style from text samples | [@robotdad](https://github.com/robotdad) | [amplifier-module-style-extraction](https://github.com/robotdad/amplifier-module-style-extraction) |
 | **module-markdown-utils** | Markdown parsing, injection, and metadata extraction utilities | [@robotdad](https://github.com/robotdad) | [amplifier-module-markdown-utils](https://github.com/robotdad/amplifier-module-markdown-utils) |
+| **module-deepresearch** | Multi-provider deep research with OpenAI (o3/o4-mini) and Anthropic Claude for automated research workflows | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-module-deepresearch](https://github.com/michaeljabbour/amplifier-module-deepresearch) |
 
 ### Hooks
 


### PR DESCRIPTION
## Summary

- Adds amplifier-module-deepresearch to the Community Modules > Tools section in docs/MODULES.md

## About the Module

[amplifier-module-deepresearch](https://github.com/michaeljabbour/amplifier-module-deepresearch) is a multi-provider deep research module supporting:

- **OpenAI Deep Research** (o3-deep-research, o4-mini-deep-research)
- **Anthropic Claude** with iterative web search capabilities
- **Automatic provider selection** based on query complexity and requirements
- **Full citation tracking** and metadata extraction

The module enables automated research workflows with comprehensive source attribution.

## Test plan

- [x] Verified entry renders correctly in markdown table format
- [x] Link to repository is valid and accessible

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>