### PR TITLE
docs: Fix incorrect recipe invocation commands in ecosystem docs

### DIFF
--- a/context/ecosystem-overview.md
+++ b/context/ecosystem-overview.md
@@ -79,17 +79,28 @@ Multi-step AI agent orchestration for repeatable workflows:
 
 **Want to know what's been happening across the Amplifier ecosystem?** Use the ecosystem activity report recipe:
 
+**In a session (recommended):**
+```
+"run the ecosystem-activity-report recipe"
+"show me all ecosystem activity since yesterday"
+"what has robotdad been working on this week?"
+```
+
+**From CLI:**
 ```bash
 # Your activity today (default)
-amplifier recipes execute amplifier:recipes/ecosystem-activity-report.yaml
+amplifier tool invoke recipes operation=execute \
+  recipe_path=amplifier:recipes/ecosystem-activity-report.yaml
 
 # All ecosystem activity since yesterday
-amplifier recipes execute amplifier:recipes/ecosystem-activity-report.yaml \
-  --context '{"activity_scope": "all", "date_range": "since yesterday"}'
+amplifier tool invoke recipes operation=execute \
+  recipe_path=amplifier:recipes/ecosystem-activity-report.yaml \
+  context='{"activity_scope": "all", "date_range": "since yesterday"}'
 
 # Specific user's activity last week
-amplifier recipes execute amplifier:recipes/ecosystem-activity-report.yaml \
-  --context '{"activity_scope": "robotdad", "date_range": "last week"}'
+amplifier tool invoke recipes operation=execute \
+  recipe_path=amplifier:recipes/ecosystem-activity-report.yaml \
+  context='{"activity_scope": "robotdad", "date_range": "last week"}'
 ```
 
 This recipe automatically:

--- a/context/recipes-usage.md
+++ b/context/recipes-usage.md
@@ -2,6 +2,21 @@
 
 This guide explains how to use the generic recipes from the `recipes` bundle for Amplifier ecosystem-specific workflows.
 
+## How to Run Recipes
+
+**In a session (recommended):** Just ask naturally:
+```
+"run repo-activity-analysis for this repo"
+"analyze ecosystem activity since yesterday"
+```
+
+**From CLI:** Use `amplifier tool invoke recipes`:
+```bash
+amplifier tool invoke recipes operation=execute recipe_path=<recipe> context='{"key": "value"}'
+```
+
+> **Note**: There is no `amplifier recipes` CLI command. Recipes are invoked via the `recipes` tool.
+
 ## Prerequisites
 
 Ensure the `recipes` bundle is loaded. The recipes bundle provides the `tool-recipes` module and generic recipe examples.
@@ -19,13 +34,22 @@ The recipes bundle includes these generic recipes in `recipes:examples/`:
 
 The simplest use case - analyze the repo you're currently in:
 
+**In a session:**
+```
+"analyze this repo's activity since yesterday"
+"run repo-activity-analysis for the last 7 days"
+```
+
+**From CLI:**
 ```bash
 # Analyze current repo since yesterday
-amplifier recipes execute recipes:examples/repo-activity-analysis.yaml
+amplifier tool invoke recipes operation=execute \
+  recipe_path=recipes:examples/repo-activity-analysis.yaml
 
 # Analyze with custom date range
-amplifier recipes execute recipes:examples/repo-activity-analysis.yaml \
-  --context '{"date_range": "last 7 days"}'
+amplifier tool invoke recipes operation=execute \
+  recipe_path=recipes:examples/repo-activity-analysis.yaml \
+  context='{"date_range": "last 7 days"}'
 ```
 
 ## Amplifier Ecosystem: Analyze Repos from MODULES.md
@@ -71,22 +95,24 @@ jq '[.[] | select(.name | test("amplifier-core|amplifier-foundation"))]' repos-m
 
 ### Step 3: Run Multi-Repo Analysis
 
+**In a session:**
+```
+"run multi-repo-activity-report using repos-manifest.json since yesterday"
+```
+
+**From CLI:**
 ```bash
-amplifier recipes execute recipes:examples/multi-repo-activity-report.yaml \
-  --context '{"repos_manifest": "./repos-manifest.json", "date_range": "since yesterday"}'
+amplifier tool invoke recipes operation=execute \
+  recipe_path=recipes:examples/multi-repo-activity-report.yaml \
+  context='{"repos_manifest": "./repos-manifest.json", "date_range": "since yesterday"}'
 ```
 
 Or with an inline repos array:
 
 ```bash
-amplifier recipes execute recipes:examples/multi-repo-activity-report.yaml \
-  --context '{
-    "repos": [
-      {"owner": "microsoft", "name": "amplifier-core"},
-      {"owner": "microsoft", "name": "amplifier-foundation"}
-    ],
-    "date_range": "last 7 days"
-  }'
+amplifier tool invoke recipes operation=execute \
+  recipe_path=recipes:examples/multi-repo-activity-report.yaml \
+  context='{"repos": [{"owner": "microsoft", "name": "amplifier-core"}, {"owner": "microsoft", "name": "amplifier-foundation"}], "date_range": "last 7 days"}'
 ```
 
 ## Example: Full Ecosystem Activity Report
@@ -106,8 +132,9 @@ grep -oE 'https://github.com/microsoft/[^)>\s"]+' amplifier/docs/MODULES.md | \
   > amplifier-repos.json
 
 # 3. Run the multi-repo analysis
-amplifier recipes execute recipes:examples/multi-repo-activity-report.yaml \
-  --context '{"repos_manifest": "./amplifier-repos.json", "date_range": "since yesterday"}'
+amplifier tool invoke recipes operation=execute \
+  recipe_path=recipes:examples/multi-repo-activity-report.yaml \
+  context='{"repos_manifest": "./amplifier-repos.json", "date_range": "since yesterday"}'
 
 # 4. Find the report
 cat ./ai_working/reports/activity-report.md

--- a/recipes/repo-activity-analysis.yaml
+++ b/recipes/repo-activity-analysis.yaml
@@ -44,18 +44,22 @@ tags: ["github", "analysis", "commits", "prs", "git", "activity"]
 # v1.1.0: Converted bash-heavy steps to type: "bash" for efficiency
 #         (no LLM overhead for deterministic shell commands)
 #
-# Usage (defaults - analyze current repo since yesterday):
-#   amplifier recipes execute repo-activity-analysis.yaml
+# Usage (in a session - recommended):
+#   "run repo-activity-analysis"
+#   "analyze this repo's activity for the last week"
 #
-# Usage (explicit repo):
-#   amplifier recipes execute repo-activity-analysis.yaml --context '{
-#     "repo_url": "https://github.com/microsoft/amplifier-core"
-#   }'
+# Usage (CLI - defaults, analyze current repo since yesterday):
+#   amplifier tool invoke recipes operation=execute recipe_path=repo-activity-analysis.yaml
 #
-# Usage (custom date range):
-#   amplifier recipes execute repo-activity-analysis.yaml --context '{
-#     "date_range": "last 7 days"
-#   }'
+# Usage (CLI - explicit repo):
+#   amplifier tool invoke recipes operation=execute \
+#     recipe_path=repo-activity-analysis.yaml \
+#     context='{"repo_url": "https://github.com/microsoft/amplifier-core"}'
+#
+# Usage (CLI - custom date range):
+#   amplifier tool invoke recipes operation=execute \
+#     recipe_path=repo-activity-analysis.yaml \
+#     context='{"date_range": "last 7 days"}'
 #
 # Requirements:
 #   - gh CLI installed and authenticated


### PR DESCRIPTION
## Summary
- Fixed documentation showing incorrect recipe invocation commands
- Updated to show correct methods:
  1. **Conversational**: Ask Claude to "run the X recipe"
  2. **CLI**: `amplifier tool invoke recipes operation=execute recipe_path=...`

## Files changed
- `context/ecosystem-overview.md`: Fixed ecosystem activity report examples
- `context/recipes-usage.md`: Complete rewrite with correct invocation methods
- `recipes/repo-activity-analysis.yaml`: Updated usage comments

## Test plan
- [x] Documentation review
- [x] Verified command syntax is correct

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>