### PR TITLE
docs: add hooks-concise-display to community modules

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -261,6 +261,7 @@ Modules built by the community.
 | Module | Description | Author | Repository |
 |--------|-------------|--------|------------|
 | **hooks-event-broadcast** | Transport-agnostic event broadcasting for streaming UI applications | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-module-hooks-event-broadcast](https://github.com/michaeljabbour/amplifier-module-hooks-event-broadcast) |
+| **hooks-concise-display** | Cleaner, more condensed terminal output for Amplifier sessions | [@obra](https://github.com/obra) | [amplifier-module-hooks-concise-display](https://github.com/obra/amplifier-module-hooks-concise-display) |
 
 ### Contributing Your Modules
 


### PR DESCRIPTION
## Summary

Adds **hooks-concise-display** module to the community hooks section of MODULES.md.

## Module Description

This module provides cleaner, more condensed terminal output for Amplifier sessions with features like:

- **Condensed tool calls**: `→ bash: ls /tmp` with colorized output
- **Compact thinking blocks**: Shows first few lines with `(+N more lines)` indicator
- **Unified diff display**: File edits shown as colored diffs with context
- **Token stats**: Minimal `└─ 54k tokens in (97% cached) · 646 out` format
- **Rich colors**: Blue for tools/thinking, green/red for diffs, dim for secondary info

## Repository

https://github.com/obra/amplifier-module-hooks-concise-display

## License

MIT

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)