### PR TITLE
docs: add browser and web-ux-dev bundles to community list

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -228,6 +228,8 @@ Bundles built by the community.
 | **expert-cookbook** | Achieve the State of the Art with Microsoft Amplifier | [@DavidKoleczek](https://github.com/DavidKoleczek) | [amplifier-expert-cookbook](https://github.com/DavidKoleczek/amplifier-expert-cookbook) |
 | **memory** | Persistent memory system with automatic capture, progressive disclosure context injection, and event broadcasting | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-bundle-memory](https://github.com/michaeljabbour/amplifier-bundle-memory) |
 | **perplexity** | Deep web research capabilities using Perplexity's Agentic Research API with citations and cost-aware guidance | [@colombod](https://github.com/colombod) | [amplifier-bundle-perplexity](https://github.com/colombod/amplifier-bundle-perplexity) |
+| **browser** | Browser automation for AI agents using agent-browser - JS rendering, auth flows, form filling, and web research | [@samueljklee](https://github.com/samueljklee) | [amplifier-bundle-browser](https://github.com/samueljklee/amplifier-bundle-browser) |
+| **web-ux-dev** | Web UX development tools - visual regression testing, console debugging, and pre-commit verification (extends browser bundle) | [@colombod](https://github.com/colombod) | [amplifier-bundle-web-ux-dev](https://github.com/colombod/amplifier-bundle-web-ux-dev) |
 
 **Want to share your bundle?** Submit a PR to add your Amplifier bundle to this list!
 


### PR DESCRIPTION
## Summary

Add two browser-related community bundles to MODULES.md:

### 1. browser (@samueljklee)
- **Repository**: https://github.com/samueljklee/amplifier-bundle-browser
- **Description**: Browser automation for AI agents using agent-browser
- **Capabilities**: JS rendering, auth flows, form filling, web research

### 2. web-ux-dev (@colombod)
- **Repository**: https://github.com/colombod/amplifier-bundle-web-ux-dev
- **Description**: Web UX development tools for testing and verification
- **Capabilities**: Visual regression testing, console debugging, pre-commit verification
- **Note**: Extends the browser bundle with dev-focused workflows

## Why Both?

These bundles are **complementary**:
- `browser` provides general browser automation primitives
- `web-ux-dev` extends it with development testing/verification workflows

Together they address the need for AI agents to visually verify browser UI during frontend development.

## Changes

- Added 2 entries to Community Bundles section in `docs/MODULES.md`