### PR TITLE
docs: add tui-tester to community bundles

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -229,6 +229,7 @@ Bundles built by the community.
 | **memory** | Persistent memory system with automatic capture, progressive disclosure context injection, and event broadcasting | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-bundle-memory](https://github.com/michaeljabbour/amplifier-bundle-memory) |
 | **perplexity** | Deep web research capabilities using Perplexity's Agentic Research API with citations and cost-aware guidance | [@colombod](https://github.com/colombod) | [amplifier-bundle-perplexity](https://github.com/colombod/amplifier-bundle-perplexity) |
 | **browser** | Browser automation for AI agents using agent-browser - JS rendering, auth flows, form filling, and web research | [@samueljklee](https://github.com/samueljklee) | [amplifier-bundle-browser](https://github.com/samueljklee/amplifier-bundle-browser) |
+| **tui-tester** | AI-assisted testing for TUI applications - spawn, drive, and capture Textual/terminal apps with visual analysis | [@colombod](https://github.com/colombod) | [amplifier-bundle-tui-tester](https://github.com/colombod/amplifier-bundle-tui-tester) |
 | **web-ux-dev** | Web UX development tools - visual regression testing, console debugging, and pre-commit verification (extends browser bundle) | [@colombod](https://github.com/colombod) | [amplifier-bundle-web-ux-dev](https://github.com/colombod/amplifier-bundle-web-ux-dev) |
 
 **Want to share your bundle?** Submit a PR to add your Amplifier bundle to this list!


### PR DESCRIPTION
## Summary
- Adds **tui-tester** bundle to the Community Bundles section of MODULES.md
- Bundle provides AI-assisted testing for TUI (Terminal User Interface) applications
- Features: spawn TUI apps in headless terminals, drive interactions via keystrokes, capture screenshots, and analyze with AI vision
- Repository: https://github.com/colombod/amplifier-bundle-tui-tester

## Test plan
- [x] Bundle tested in shadow environment and verified working
- [x] MODULES.md format follows existing community bundle entries

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)