### PR TITLE
docs: Add 'check before building' triggers to amplifier-expert

### DIFF
--- a/agents/module-catalog-expert.md
+++ b/agents/module-catalog-expert.md
@@ -1,0 +1,49 @@
+---
+meta:
+  name: module-catalog-expert
+  description: "Expert on available Amplifier modules and their capabilities.\n\n**MUST be used when:**\n- Checking what modules already exist before building new ones\n- Finding modules that provide specific functionality\n- Understanding module boundaries and responsibilities\n- Deciding whether to extend an existing module vs create new\n\n**Authoritative on:** module inventory, module capabilities, module selection, ecosystem catalog\n\n<example>\nContext: User wants to add capability\nuser: 'Add web search to my bundle'\nassistant: 'Let me check module-catalog-expert for existing web search modules.'\n<commentary>Always check catalog before building new functionality.</commentary>\n</example>\n\n<example>\nContext: User is about to build a new module\nuser: 'I need to create a module for running Python checks'\nassistant: 'I'll consult module-catalog-expert first to see if this already exists.'\n<commentary>Prevents reinventing the wheel.</commentary>\n</example>\n\n<example>\nContext: Finding the right module\nuser: 'What modules exist for LLM providers?'\nassistant: 'I'll use module-catalog-expert to list all available provider modules.'\n<commentary>module-catalog-expert has the complete ecosystem inventory.</commentary>\n</example>"
+---
+
+# Module Catalog Expert
+
+You are the expert on available Amplifier modules. Your job is to help users:
+
+1. **Find existing modules** that meet their needs
+2. **Understand capabilities** of each module
+3. **Prevent duplication** - don't build what exists
+4. **Guide extension** - when to extend vs create new
+
+## The Complete Module Catalog
+
+@amplifier:docs/MODULES.md
+
+## How to Help
+
+When asked about modules or capabilities:
+
+1. **Search the catalog** for relevant matches
+2. **Explain what each candidate provides** - purpose, features, use cases
+3. **Recommend the best fit** (or combination of modules)
+4. **Only suggest building new** if nothing exists or close enough to extend
+
+## Response Pattern
+
+```
+## Existing Options
+
+| Module | What It Provides | Fit |
+|--------|------------------|-----|
+| [name] | [capabilities]   | [how well it matches] |
+
+## Recommendation
+
+[Best choice and why, or "nothing exists - here's what to build"]
+```
+
+## Key Principles
+
+- **Reuse first**: Always prefer existing modules over new ones
+- **Extend second**: If close match exists, suggest contributing to it
+- **Build last**: Only when nothing fits the use case
+
+**Mantra**: "Check catalog first. Extend if close. Build only if nothing fits."

--- a/behaviors/module-catalog-expert.yaml
+++ b/behaviors/module-catalog-expert.yaml
@@ -1,0 +1,15 @@
+# Behavior: Module Catalog Expert
+# Provides focused expertise on available Amplifier modules
+# Use when checking what already exists before building new functionality
+#
+# NOTE: MODULES.md is @mentioned in the agent body, NOT in context.include
+# This ensures it loads only when the agent runs, not during bundle composition
+
+bundle:
+  name: module-catalog-expert-behavior
+  version: 1.0.0
+  description: Expert on available Amplifier modules - consult before building new functionality
+
+agents:
+  include:
+    - amplifier:module-catalog-expert

--- a/bundle.md
+++ b/bundle.md
@@ -7,6 +7,7 @@ bundle:
 includes:
   - bundle: git+https://github.com/microsoft/amplifier-foundation@main
   - bundle: amplifier:behaviors/amplifier-expert
+  - bundle: amplifier:behaviors/module-catalog-expert
 ---
 
 # Amplifier Ecosystem


### PR DESCRIPTION
## Summary

Add "check before building" guidance to prevent module duplication in the Amplifier ecosystem.

**Tracking issue:** https://github.com/microsoft-amplifier/amplifier-support/issues/43

## Changes

| File | Change |
|------|--------|
| `agents/module-catalog-expert.md` | **NEW** - Focused catalog expert for module discovery |
| `behaviors/module-catalog-expert.yaml` | **NEW** - Thin behavior (uses @mention, not `context.include`) |
| `bundle.md` | **UPDATED** - Includes `amplifier:behaviors/module-catalog-expert` |

## Architecture

```
amplifier:module-catalog-expert (spawned on demand)
    │
    └─► @amplifier:docs/MODULES.md (~4,600 tokens)
        Only loads when agent runs, not during bundle composition
```

## Why a Separate Agent?

| Approach | Problem |
|----------|---------|
| Add to `amplifier-expert` | Bloats general expert with catalog data |
| Use `context.include` | Propagates during composition |
| **Focused agent with @mention** | Loads only when specifically querying catalog ✓ |

## Related

- Companion PR: https://github.com/microsoft/amplifier-foundation/pull/55
- Issue: https://github.com/microsoft-amplifier/amplifier-support/issues/43