### PR TITLE
docs: add loop-safety bundle and hooks-insight-blocks to community catalog

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -317,6 +317,16 @@ Built something cool? Share it with the community!
   - Compatible: Amplifier 0.1.x
   - Status: Experimental
 
+- **bundle-loop-safety** by @michaeljabbour - Loop detection and safe orchestration with automatic circuit-breaking to prevent runaway agent loops
+  - Repository: https://github.com/michaeljabbour/amplifier-bundle-loop-safety
+  - Compatible: Amplifier 0.1.x
+  - Status: Active
+
+- **hooks-insight-blocks** by @michaeljabbour - Generate structured insight blocks that inject contextual knowledge and explanations into agent responses
+  - Repository: https://github.com/michaeljabbour/amplifier-module-hooks-insight-blocks
+  - Compatible: Amplifier 0.1.x
+  - Status: Active
+
 ---
 
 ## Building Your Own Modules


### PR DESCRIPTION
## Community Contributions

Add two community modules to MODULES.md:

### amplifier-bundle-loop-safety
Loop detection and safe orchestration with automatic circuit-breaking to prevent runaway agent loops. Includes an inline orchestrator module (loop-safe) and a hook module (loop-detector) that monitors for repetitive patterns.

- Repository: https://github.com/michaeljabbour/amplifier-bundle-loop-safety
- Compatible: Amplifier 0.1.x

### amplifier-module-hooks-insight-blocks
Structured insight blocks that inject contextual knowledge and explanations into agent responses. Subscribes to kernel lifecycle events to enrich output with relevant context.

- Repository: https://github.com/michaeljabbour/amplifier-module-hooks-insight-blocks
- Compatible: Amplifier 0.1.x

---

Both modules follow Amplifier conventions:
- Standard `mount(coordinator, config)` protocol
- `amplifier-core` as dev-only peer dependency
- Entry-points registered via `[project.entry-points."amplifier.modules"]`
- Public source code with README documentation