### PR TITLE
docs: add community provider-huggingface module

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -317,6 +317,11 @@ Built something cool? Share it with the community!
   - Compatible: Amplifier 0.1.x
   - Status: Experimental
 
+- **provider-huggingface** by @michaeljabbour - HuggingFace Inference API provider for chat completions with any HuggingFace model
+  - Repository: https://github.com/michaeljabbour/amplifier-module-provider-huggingface
+  - Compatible: Amplifier 0.1.x
+  - Status: Active
+
 ---
 
 ## Building Your Own Modules


### PR DESCRIPTION
Adds the HuggingFace Inference API provider module to the community modules catalog.

## Module Details

- **Name**: provider-huggingface
- **Repository**: https://github.com/michaeljabbour/amplifier-module-provider-huggingface
- **Author**: @michaeljabbour
- **Description**: HuggingFace Inference API provider for chat completions with any HuggingFace model

## What it does

Integrates HuggingFace models into Amplifier via the OpenAI-compatible chat completions endpoint. Supports both Serverless Inference API and dedicated Inference Endpoints.

Features:
- Full Amplifier Provider protocol (structural typing)
- Lazy AsyncInferenceClient initialization
- Tool call support with missing-result repair
- Event emission (llm:request/response at info/debug/raw levels)
- Curated model list (Llama 3.x, Qwen 2.5, Mixtral, DeepSeek R1, Phi-3)
- Configurable base_url for Inference Endpoints

Built following the exact same patterns as provider-anthropic, provider-openai, and provider-ollama.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)