### PR TITLE
docs: add superpowers bundle to module catalog

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -60,6 +60,7 @@ Composable configuration packages that combine providers, behaviors, agents, and
 | **rust-dev** | Comprehensive Rust development tools — code quality (cargo fmt, clippy, cargo check), LSP integration, and expert agent | [amplifier-bundle-rust-dev](https://github.com/microsoft/amplifier-bundle-rust-dev) |
 | **shadow** | OS-level sandboxed environments for testing local Amplifier ecosystem changes safely | [amplifier-bundle-shadow](https://github.com/microsoft/amplifier-bundle-shadow) |
 | **stories** | Autonomous storytelling engine with 11 specialist agents, 4 output formats (HTML, Excel, Word, PDF), and automated recipes for case studies, release notes, and weekly digests | [amplifier-bundle-stories](https://github.com/microsoft/amplifier-bundle-stories) |
+| **superpowers** | TDD-driven development workflows with brainstorm, plan, execute, verify, and finish modes — includes specialized agents and a full development cycle recipe | [amplifier-bundle-superpowers](https://github.com/microsoft/amplifier-bundle-superpowers) |
 | **ts-dev** | Comprehensive TypeScript/JavaScript development tools - code quality, LSP, and expert agent | [amplifier-bundle-ts-dev](https://github.com/microsoft/amplifier-bundle-ts-dev) |
 
 **Usage**: Bundles are loaded via the `amplifier bundle` commands:


### PR DESCRIPTION
## Summary
- Add `amplifier-bundle-superpowers` entry to the Bundles table in `docs/MODULES.md`
- Placed alphabetically between `stories` and `ts-dev`
- The superpowers bundle provides TDD-driven development workflows with brainstorm, plan, execute, verify, and finish modes

## Test plan
- [x] Verified entry is in correct alphabetical order
- [x] Verified table formatting is consistent with other entries
- [x] Verified repo link points to correct GitHub repository

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)