### PR TITLE
docs: add provider-github-copilot to module catalog

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -113,6 +113,7 @@ Connect to AI model providers.
 | **provider-gemini** | Google Gemini integration with 1M context and thinking | [amplifier-module-provider-gemini](https://github.com/microsoft/amplifier-module-provider-gemini) |
 | **provider-vllm** | vLLM server integration for self-hosted models | [amplifier-module-provider-vllm](https://github.com/microsoft/amplifier-module-provider-vllm) |
 | **provider-ollama** | Local Ollama models for offline development | [amplifier-module-provider-ollama](https://github.com/microsoft/amplifier-module-provider-ollama) |
+| **provider-github-copilot** | GitHub Copilot models via the Copilot SDK | [amplifier-module-provider-github-copilot](https://github.com/microsoft/amplifier-module-provider-github-copilot) |
 | **provider-mock** | Mock provider for testing without API calls | [amplifier-module-provider-mock](https://github.com/microsoft/amplifier-module-provider-mock) |
 
 ### Tools


### PR DESCRIPTION
## Summary
- Add `amplifier-module-provider-github-copilot` to the Providers section of MODULES.md
- This module enables access to GitHub Copilot models via the Copilot SDK

## Test plan
- [x] Verified entry is correctly placed in the Providers table (before `provider-mock`)
- [x] Link points to the correct repository at `microsoft/amplifier-module-provider-github-copilot`

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)