### PR TITLE
feat: switch amplifier-core to PyPI, align app-cli to main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ build-backend = "hatchling.build"
 package = true
 
 [tool.uv.sources]
-amplifier-app-cli = { git = "https://github.com/microsoft/amplifier-app-cli", branch = "rust-core" }
+amplifier-app-cli = { git = "https://github.com/microsoft/amplifier-app-cli", branch = "main" }
 
 [tool.hatch.build.targets.wheel]
 packages = [


### PR DESCRIPTION
Removes amplifier-core git source override (resolves from PyPI). Points amplifier-app-cli to main branch.