### PR TITLE
docs: align entrypoint guidance, onboarding links, and module catalog references

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ amplifier-log-viewer
 Amplifier works with multiple AI providers:
 
 - **Anthropic Claude** - Recommended, most tested (Sonnet 4.5, Opus 4.6, Haiku 4.5)
-- **OpenAI** - Good alternative (GPT-5.2, GPT-5.2-Pro, GPT-5.1-Codex)
+- **OpenAI** - Good alternative (GPT-5.4, GPT-5.4-Pro, GPT-5.4-Codex)
 - **Azure OpenAI** - Enterprise users with Azure subscriptions (supports managed identity)
 - **Ollama** - Local, free, no API key needed (llama3, codellama, etc.)
 
@@ -255,13 +255,12 @@ amplifier run --bundle recipes "Your prompt"
 amplifier bundle use foundation
 ```
 
-**The `foundation` bundle** is the default and includes:
+**The `foundation` bundle** is the default bare-minimum configuration:
 
-- **Tools**: filesystem, bash, web, search, task delegation
-- **Agents**: 14 specialized agents (zen-architect, bug-hunter, git-ops, web-research, explorer, etc.)
-- **Behaviors**: logging, redaction, streaming UI, todo tracking
+- **Tools**: filesystem, bash
+- **Agents**: None (agents ship in other bundles such as `dev`)
 
-Most users never need to change bundles—foundation provides everything for development work.
+Add bundles like `dev`, `recipes`, or `design-intelligence` for richer tooling and specialized agents.
 
 ### Working with Agents
 

--- a/docs/REPOSITORY_RULES.md
+++ b/docs/REPOSITORY_RULES.md
@@ -185,37 +185,7 @@ Modules are loaded using amplifier-foundation's internal APIs directly.
 
 ### Modules (Kernel Extensions)
 
-**Context Managers**:
-- amplifier-module-context-persistent
-- amplifier-module-context-simple
-
-**Hooks**:
-- amplifier-module-hooks-approval
-- amplifier-module-hooks-backup
-- amplifier-module-hooks-logging
-- amplifier-module-hooks-redaction
-- amplifier-module-hooks-scheduler-cost-aware
-- amplifier-module-hooks-scheduler-heuristic
-- amplifier-module-hooks-streaming-ui
-
-**Orchestrators**:
-- amplifier-module-loop-basic
-- amplifier-module-loop-events
-- amplifier-module-loop-streaming
-
-**Providers**:
-- amplifier-module-provider-anthropic
-- amplifier-module-provider-azure-openai
-- amplifier-module-provider-mock
-- amplifier-module-provider-ollama
-- amplifier-module-provider-openai
-
-**Tools**:
-- amplifier-module-tool-bash
-- amplifier-module-tool-filesystem
-- amplifier-module-tool-search
-- amplifier-module-tool-task
-- amplifier-module-tool-web
+For the current list of all runtime modules (orchestrators, providers, tools, context managers, hooks), see **[Module Catalog](MODULES.md)**.
 
 **All Modules**:
 - **Referenced By**: Apps/libraries via mount plans

--- a/docs/USER_ONBOARDING.md
+++ b/docs/USER_ONBOARDING.md
@@ -92,7 +92,7 @@ Which bundle? [1] foundation [2] dev [3] full: 1
 Ready! Try: amplifier run "Hello world"
 ```
 
-**Note:** Azure OpenAI has additional setup (endpoint, deployment name, auth method). See examples in [amplifier/README.md](../amplifier/README.md#quick-start).
+**Note:** Azure OpenAI has additional setup (endpoint, deployment name, auth method). See examples in [README.md](../README.md#quick-start).
 
 **That's it!** You're configured and ready to use Amplifier.
 
@@ -634,10 +634,10 @@ When no scope specified, commands prompt interactively.
 ### Essential Reading
 
 - **[Bundle Guide](https://github.com/microsoft/amplifier-foundation/blob/main/docs/BUNDLE_GUIDE.md)** - Creating and using bundles
-- [SCENARIO_TOOLS_GUIDE.md](SCENARIO_TOOLS_GUIDE.md) - Building sophisticated CLI tools
+- [Module Catalog](MODULES.md) - Available components and module development
 - **[Agent Authoring](https://github.com/microsoft/amplifier-foundation/blob/main/docs/AGENT_AUTHORING.md)** - Create custom agents
-- [TOOLKIT_GUIDE.md](TOOLKIT_GUIDE.md) - Toolkit utilities for building tools
-- [context/KERNEL_PHILOSOPHY.md](context/KERNEL_PHILOSOPHY.md) - Core design principles
+- [Developer Guide](DEVELOPER.md) - Building modules and extending Amplifier
+- [Kernel Philosophy](https://github.com/microsoft/amplifier-core/blob/main/docs/KERNEL_PHILOSOPHY.md) - Core design principles
 
 ---
 
@@ -655,4 +655,4 @@ amplifier run "Explain the kernel design in @docs/AMPLIFIER_AS_LINUX_KERNEL.md"
 
 The file content loads automatically while your @mention stays as a reference marker.
 
-**Learn more**: See [MENTION_PROCESSING.md](MENTION_PROCESSING.md) for complete guide.
+**Learn more**: See [User Guide](USER_GUIDE.md) for the complete reference.


### PR DESCRIPTION
## Summary

- **Foundation bundle row** corrected to bare-minimum wording
- **OpenAI model names** updated to GPT-5.4 family
- **Stale hardcoded module list** replaced with `MODULES.md` pointer
- **Onboarding broken/nonexistent links** replaced with valid targets

## Test plan

- [x] `tests/test_doc_sweep.sh` passes
- [x] All three changed files reviewed for link validity
- [x] No unrelated files modified

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)