### PR TITLE
docs: add terminal-tester bundle to component catalog

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -67,6 +67,7 @@ Composable configuration packages that combine providers, behaviors, agents, and
 | **stories** | Autonomous storytelling engine with 11 specialist agents, 4 output formats (HTML, Excel, Word, PDF), and automated recipes for case studies, release notes, and weekly digests | [amplifier-bundle-stories](https://github.com/microsoft/amplifier-bundle-stories) |
 | **execution-environments** | Instance-based execution environments — create, target, and destroy local, Docker, and SSH environments on demand with 11 tools, composable wrappers, and NLSpec-aligned protocol | [amplifier-bundle-execution-environments](https://github.com/microsoft/amplifier-bundle-execution-environments) |
 | **superpowers** | TDD-driven development workflows with brainstorm, plan, execute, verify, and finish modes — includes specialized agents and a full development cycle recipe | [amplifier-bundle-superpowers](https://github.com/microsoft/amplifier-bundle-superpowers) |
+| **terminal-tester** | Terminal application testing and inspection with 3 specialist agents (operator, visual-tester, debugger) using dual-mode capture — screen-dump for Ratatui/crossterm, PTY/pyte for any terminal app | [amplifier-bundle-terminal-tester](https://github.com/microsoft/amplifier-bundle-terminal-tester) |
 | **ts-dev** | Comprehensive TypeScript/JavaScript development tools - code quality, LSP, and expert agent | [amplifier-bundle-ts-dev](https://github.com/microsoft/amplifier-bundle-ts-dev) |
 
 **Usage**: Bundles are loaded via the `amplifier bundle` commands:


### PR DESCRIPTION
## Summary
- Add amplifier-bundle-terminal-tester to the Bundles section of MODULES.md
- Positioned alphabetically between superpowers and ts-dev bundles

## Description
Terminal application testing and inspection with 3 specialist agents using dual-mode capture (screen-dump + PTY/pyte).

## Test plan
- ✅ Documentation builds correctly
- ✅ Link verification for new entry