### PR TITLE
docs: update youtube module registration to amplifier-youtube

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -273,7 +273,7 @@ Modules built by the community.
 
 | Module | Description | Author | Repository |
 |--------|-------------|--------|------------|
-| **tool-youtube-dl** | Download audio and video from YouTube with metadata extraction | [@robotdad](https://github.com/robotdad) | [amplifier-module-tool-youtube-dl](https://github.com/robotdad/amplifier-module-tool-youtube-dl) |
+| **youtube** | YouTube download, search, and account feed access — audio/video download, keyword and filtered search (YouTube Data API + yt-dlp fallback), watch history, subscriptions, liked videos, and more | [@robotdad](https://github.com/robotdad) | [amplifier-youtube](https://github.com/robotdad/amplifier-youtube) |
 | **tool-whisper** | Speech-to-text transcription using OpenAI's Whisper API | [@robotdad](https://github.com/robotdad) | [amplifier-module-tool-whisper](https://github.com/robotdad/amplifier-module-tool-whisper) |
 | **tool-memory** | Persistent memory tool for storing and retrieving facts across sessions | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-module-tool-memory](https://github.com/michaeljabbour/amplifier-module-tool-memory) |
 | **tool-rlm** | Recursive Language Model (RLM) for processing 10M+ token contexts via sandboxed Python REPL | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-module-tool-rlm](https://github.com/michaeljabbour/amplifier-module-tool-rlm) |


### PR DESCRIPTION
Updates the community Tools section in MODULES.md for @robotdad's YouTube module.

## Changes

- **Module ID:** `tool-youtube-dl` → `youtube`
- **Repo:** `amplifier-module-tool-youtube-dl` → `amplifier-youtube`
- **Description:** Updated to reflect three tools now provided:
  - `youtube-dl` — Download audio/video, screenshots, local file support
  - `youtube-search` — YouTube Data API v3 with yt-dlp fallback (rich filters when API key configured)
  - `youtube-feed` — Watch history, subscriptions, liked videos, recommendations, watch later (cookie auth)

## Context

The module was renamed and expanded. The GitHub repo was renamed via `gh repo rename` so the old URL redirects, but the MODULES.md entry should reflect the current canonical name and repo.