### PR TITLE
docs: consolidate memory-related entries in MODULES.md

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -246,7 +246,7 @@ Bundles built by the community.
 |--------|-------------|--------|------------|
 | **deepwiki** | AI-powered open-source project understanding via DeepWiki MCP - ask questions about any public GitHub repository | [@colombod](https://github.com/colombod) | [amplifier-bundle-deepwiki](https://github.com/colombod/amplifier-bundle-deepwiki) |
 | **expert-cookbook** | Achieve the State of the Art with Microsoft Amplifier | [@DavidKoleczek](https://github.com/DavidKoleczek) | [amplifier-expert-cookbook](https://github.com/DavidKoleczek/amplifier-expert-cookbook) |
-| **memory** | Persistent memory system with automatic capture, progressive disclosure context injection, and event broadcasting | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-bundle-memory](https://github.com/michaeljabbour/amplifier-bundle-memory) |
+| **memory** | Local-first persistent memory: MemPalace semantic retrieval, knowledge graph curation, briefing re-ranking, palace garden clustering, and JSONL event observability | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-bundle-memory](https://github.com/michaeljabbour/amplifier-bundle-memory) |
 | **parallax-discovery** | Multi-agent deep investigation methodology. Dispatches independent agent teams from different angles (code-tracer, behavior-observer, integration-mapper) to build true understanding of complex systems through progressive waves: broad discovery → focused verification → execution-based adversarial testing → synthesis. Includes 5 agents, 4 modes, 2 recipes, and a progressive-reveal skill. | [@bkrabach](https://github.com/bkrabach) | [amplifier-bundle-parallax-discovery](https://github.com/bkrabach/amplifier-bundle-parallax-discovery) |
 | **perplexity** | Deep web research capabilities using Perplexity's Agentic Research API with citations and cost-aware guidance | [@colombod](https://github.com/colombod) | [amplifier-bundle-perplexity](https://github.com/colombod/amplifier-bundle-perplexity) |
 | **browser** | Browser automation for AI agents using agent-browser - JS rendering, auth flows, form filling, and web research | [@samueljklee](https://github.com/samueljklee) | [amplifier-bundle-browser](https://github.com/samueljklee/amplifier-bundle-browser) |
@@ -278,7 +278,6 @@ Modules built by the community.
 |--------|-------------|--------|------------|
 | **tool-youtube-dl** | Download audio and video from YouTube with metadata extraction | [@robotdad](https://github.com/robotdad) | [amplifier-module-tool-youtube-dl](https://github.com/robotdad/amplifier-module-tool-youtube-dl) |
 | **tool-whisper** | Speech-to-text transcription using OpenAI's Whisper API | [@robotdad](https://github.com/robotdad) | [amplifier-module-tool-whisper](https://github.com/robotdad/amplifier-module-tool-whisper) |
-| **tool-memory** | Persistent memory tool for storing and retrieving facts across sessions | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-module-tool-memory](https://github.com/michaeljabbour/amplifier-module-tool-memory) |
 | **tool-rlm** | Recursive Language Model (RLM) for processing 10M+ token contexts via sandboxed Python REPL | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-module-tool-rlm](https://github.com/michaeljabbour/amplifier-module-tool-rlm) |
 | **module-image-generation** | Multi-provider AI image generation with DALL-E, Imagen, and GPT-Image-1 | [@robotdad](https://github.com/robotdad) | [amplifier-module-image-generation](https://github.com/robotdad/amplifier-module-image-generation) |
 | **module-style-extraction** | Extract and apply writing style from text samples | [@robotdad](https://github.com/robotdad) | [amplifier-module-style-extraction](https://github.com/robotdad/amplifier-module-style-extraction) |
@@ -288,7 +287,6 @@ Modules built by the community.
 
 | Module | Description | Author | Repository |
 |--------|-------------|--------|------------|
-| **hooks-event-broadcast** | Transport-agnostic event broadcasting for streaming UI applications | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-module-hooks-event-broadcast](https://github.com/michaeljabbour/amplifier-module-hooks-event-broadcast) |
 | **hooks-concise-display** | Cleaner, more condensed terminal output for Amplifier sessions | [@obra](https://github.com/obra) | [amplifier-module-hooks-concise-display](https://github.com/obra/amplifier-module-hooks-concise-display) |
 
 ### Contributing Your Modules


### PR DESCRIPTION
Closes #256

## Summary

Three catalog edits to `docs/MODULES.md` requested by the author (@michaeljabbour) after shipping v1.2.0 of the `memory` bundle:

1. **Updated** — `memory` bundle description to reflect v1.2.0 capabilities (MemPalace semantic retrieval, knowledge graph curation, briefing re-ranking, palace garden clustering, JSONL event observability). The previous description was written for v0.1.0.
2. **Removed** — `tool-memory` catalog entry. The module still exists on GitHub and is imported by the bundle as a dependency; the bundle is now the intended discovery path.
3. **Removed** — `hooks-event-broadcast` catalog entry. Superseded by the bundle's built-in JSONL emitter.

## Scope

- 1 file changed: `docs/MODULES.md`
- 1 insertion, 3 deletions

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
