### PR TITLE
docs: bump gpt-5.4 references to gpt-5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Authentication? [1] API key [2] Azure CLI (az login): 2
 ✓ Using DefaultAzureCredential
   (Works with 'az login' locally or managed identity in Azure)
 
-Deployment name: gpt-5.4
+Deployment name: gpt-5.5
   Note: Use your Azure deployment name, not model name
 ✓ Configured
 
@@ -121,8 +121,8 @@ API key: ••••••••
   Get one: https://platform.openai.com/api-keys
 ✓ Saved
 
-Model? [1] gpt-5.4 [2] gpt-5.4-codex [3] gpt-5.4-pro [4] custom: 1
-✓ Using gpt-5.4
+Model? [1] gpt-5.5 [2] gpt-5.4-codex [3] gpt-5.5-pro [4] custom: 1
+✓ Using gpt-5.5
 
 Ready! Starting chat...
 >
@@ -197,7 +197,7 @@ amplifier provider use openai
 
 # Or explicit
 amplifier provider use anthropic --model claude-opus-4-6
-amplifier provider use azure-openai --deployment gpt-5.4
+amplifier provider use azure-openai --deployment gpt-5.5
 ```
 
 > **Note**: We've done most of our early testing with Anthropic Claude. Other providers are supported but may have rough edges we're actively smoothing out.
@@ -332,10 +332,10 @@ amplifier provider use anthropic --model claude-opus-4-6
 amplifier provider use azure-openai
   Azure endpoint: https://my-resource.openai.azure.com/
   Auth? [1] API key [2] Azure CLI: 2
-  Deployment: gpt-5.4
+  Deployment: gpt-5.5
 
 # Configure where to save
-amplifier provider use openai --model gpt-5.4 --local      # Just you
+amplifier provider use openai --model gpt-5.5 --local      # Just you
 amplifier provider use anthropic --model claude-opus-4-6 --project  # Team
 
 # See what's active

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -122,14 +122,14 @@ amplifier provider use openai
 
 # Or explicit
 amplifier provider use anthropic --model claude-opus-4-6
-amplifier provider use openai --model gpt-5.4
+amplifier provider use openai --model gpt-5.5
 amplifier provider use ollama --model llama3
 
 # Azure OpenAI (more complex)
 amplifier provider use azure-openai --deployment gpt-5.4-codex --use-azure-cli
 
 # Configure where to save
-amplifier provider use openai --model gpt-5.4 --local    # Just you
+amplifier provider use openai --model gpt-5.5 --local    # Just you
 amplifier provider use anthropic --model claude-opus-4-6 --project  # Team
 
 # See what's active

--- a/recipes/document-generation.yaml
+++ b/recipes/document-generation.yaml
@@ -157,8 +157,8 @@
 #     * Enables resilience across different provider configurations
 #   - FALLBACK STRATEGY:
 #     * Haiku steps: anthropic haiku → openai gpt-5-mini
-#     * Sonnet steps: anthropic sonnet → openai gpt-5.4 → azure gpt-5.4
-#     * Opus steps: anthropic opus → openai gpt-5.4 → azure gpt-5.4
+#     * Sonnet steps: anthropic sonnet → openai gpt-5.5 → azure gpt-5.5
+#     * Opus steps: anthropic opus → openai gpt-5.5 → azure gpt-5.5
 #   - BACKWARD COMPATIBLE: Works with older foundation versions (uses first preference)
 #
 # v7.1.0-models (2026-01-27):
@@ -660,9 +660,9 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
           - provider: azure
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           Analyze the outline structure and compute traversal context for ALL sections.
           
@@ -741,9 +741,9 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
           - provider: azure
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           Analyze the existing document and determine what updates are needed.
           
@@ -1186,9 +1186,9 @@ stages:
           - provider: anthropic
             model: claude-opus-4-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
           - provider: azure
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           ## SECTION GENERATION: {{section_id}}
           
@@ -1308,9 +1308,9 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
           - provider: azure
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           Assemble the complete document from all generated sections.
           
@@ -1376,7 +1376,7 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           DESIGN INTELLIGENCE FEEDBACK: Voice & Tone Review (INITIAL GENERATION)
           
@@ -1441,7 +1441,7 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           DESIGN INTELLIGENCE FEEDBACK: Structure Review (INITIAL GENERATION)
           
@@ -1610,9 +1610,9 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
           - provider: azure
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           Fix STRUCTURAL issues in the document.
           
@@ -1747,9 +1747,9 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
           - provider: azure
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           ## {{check.type}} VALIDATION
           
@@ -1826,9 +1826,9 @@ stages:
           - provider: anthropic
             model: claude-opus-4-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
           - provider: azure
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           ## FIX CONTENT VALIDATION ISSUES
           
@@ -2154,9 +2154,9 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
           - provider: azure
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           ## {{check.type}} VALIDATION
           
@@ -2233,9 +2233,9 @@ stages:
           - provider: anthropic
             model: claude-opus-4-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
           - provider: azure
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           ## FIX QUALITY VALIDATION ISSUES
           
@@ -2516,9 +2516,9 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
           - provider: azure
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           FINAL VERIFICATION of the document.
           
@@ -2558,7 +2558,7 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           DESIGN INTELLIGENCE FEEDBACK: Voice & Tone Review
           
@@ -2622,7 +2622,7 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           DESIGN INTELLIGENCE FEEDBACK: Information Architecture Review
           
@@ -2686,7 +2686,7 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           DESIGN INTELLIGENCE FEEDBACK: Outline Review
           
@@ -2867,7 +2867,7 @@ stages:
           - provider: anthropic
             model: claude-sonnet-*
           - provider: openai
-            model: gpt-5.4
+            model: gpt-5.5
         prompt: |
           Generate a summary report of the document generation process.
           

--- a/tests/test_doc_sweep.sh
+++ b/tests/test_doc_sweep.sh
@@ -47,21 +47,21 @@ check "README.md has no gpt-5.1 references" \
 check "README.md has no gpt-5.2 references" \
     "empty" grep -n "gpt-5\.2" README.md
 
-check "README.md has gpt-5.4 references (replacements applied)" \
+check "README.md has gpt-5.5 references (replacements applied)" \
     "nonempty" grep -n "gpt-5\.4" README.md
 
 # USER_GUIDE.md checks
 check "USER_GUIDE.md has no gpt-5.1 references" \
     "empty" grep -n "gpt-5\.1" docs/USER_GUIDE.md
 
-check "USER_GUIDE.md has gpt-5.4 references (replacements applied)" \
+check "USER_GUIDE.md has gpt-5.5 references (replacements applied)" \
     "nonempty" grep -n "gpt-5\.4" docs/USER_GUIDE.md
 
 # document-generation.yaml checks
 check "document-generation.yaml has no gpt-4o references" \
     "empty" grep -n "gpt-4o" recipes/document-generation.yaml
 
-check "document-generation.yaml has gpt-5.4 references" \
+check "document-generation.yaml has gpt-5.5 references" \
     "nonempty" grep -n "gpt-5\.4" recipes/document-generation.yaml
 
 check "document-generation.yaml has gpt-5-mini references (correct replacement)" \


### PR DESCRIPTION
## Summary

Updated documentation, examples, and recipes to reference GPT-5.5 as the default model in place of GPT-5.4.

## Changes

- `README.md`: Updated example references and model descriptions
- `docs/USER_GUIDE.md`: Updated user-facing documentation and examples
- `recipes/document-generation.yaml`: Updated model references in OpenAI fallback chain
- `tests/test_doc_sweep.sh`: Updated documentation examples and assertions

## What stayed on GPT-5.4

- `gpt-5.4-codex`: OpenAI has not shipped a GPT-5.5-codex variant; Codex tier remains on 5.4
- `gpt-5.4-mini` guards: No gpt-5.5-mini equivalent shipped yet; economy tests continue to require `gpt-5.4-mini` where specified
- Resolver docstring examples: Stable illustrative material, model version is not critical

## Dependencies

- Depends on microsoft/amplifier-module-provider-openai#30 (provides gpt-5.5 capability)
- Depends on microsoft/amplifier-bundle-routing-matrix#17 (updated routing matrices)

These PRs should land in dependency order: provider → routing → docs.