### PR TITLE
docs(amplifier-expert): add CONTRACTS.md + lifecycle concept + 2 anti-patterns

### DIFF
--- a/agents/amplifier-expert.md
+++ b/agents/amplifier-expert.md
@@ -60,6 +60,7 @@ The ultra-thin kernel providing mechanisms only (~2,600 lines). This is the foun
 
 **Key Documents:**
 - @core:README.md - Kernel overview
+- @core:CONTRACTS.md - Authoritative source for module protocols and lifecycle methods
 - @core:docs/DESIGN_PHILOSOPHY.md - Why the kernel is tiny and boring
 - @core:docs/HOOKS_API.md - Hook system for observability and control
 
@@ -71,6 +72,7 @@ The ultra-thin kernel providing mechanisms only (~2,600 lines). This is the foun
 - **Coordinator**: Infrastructure context (session_id, hooks, mount points)
 - **Mount Plan**: Configuration dict specifying modules to load
 - **Module Protocols**: Tool, Provider, Orchestrator, ContextManager, Hook
+- **Module Lifecycle**: `mount()` and the optional `on_session_ready()` hook fired after all modules mount. See core:core-expert for depth, or `@core:CONTRACTS.md` for the contract.
 
 **When to consult core:core-expert**: For deep kernel contract questions, module protocol details, or deciding if something belongs in kernel vs module.
 
@@ -286,6 +288,8 @@ When you see these, redirect:
 4. **Policy in kernel** - Trying to add decisions to core instead of modules
 5. **Over-engineering** - Building for hypothetical futures
 6. **Context poisoning** - Duplicate/conflicting documentation
+7. **`register_capability` for shared channels** - Using `register_capability` for multi-contributor channels like `observability.events`. Symptom: events you contributed don't show up — `collect_contributions()` returns nothing because `register_capability` creates singleton ownership invisible to the channels dict. Fix: use `register_contributor`. See `core:docs/specs/CONTRIBUTION_CHANNELS.md`.
+8. **Polluted test environment masking runtime deps** - Assuming your test env has the same dep surface as a clean end-user install. Symptom: smoke tests pass; `pip install <package>` followed by import fails with `ModuleNotFoundError`. Why: dev/test deps (pytest, etc.) pull in transitives that mask missing runtime declarations. Fix: pristine-import test in `python:*-slim` Docker before publishing; declare runtime deps explicitly in `pyproject.toml`. Reference: `core:context/release-mandate.md` Incident History #5 (v1.4.0 yank).
 
 ---
 


### PR DESCRIPTION
## Summary

Three small additions to `agents/amplifier-expert.md` so the ecosystem router surfaces recent changes:

1. **Tier 0 Key Documents** — add `@core:CONTRACTS.md` (was missing entirely; the authoritative source for module protocols and the new lifecycle)
2. **Key Kernel Concepts** — add Module Lifecycle as a fifth concept (`mount()` + optional `on_session_ready()`); placed in concepts, not Module Types Reference, to keep lifecycle distinct from module type taxonomy
3. **Anti-Patterns to Flag** — append two entries:
   - `register_capability` for shared channels (symptom + cause + fix; cites `CONTRIBUTION_CHANNELS.md`)
   - Polluted test environment masking runtime deps (the v1.4.0 lesson; cites `release-mandate` Incident #5)

This is a docs-only PR. One file, +4 −0 lines.

## Why now

- **amplifier-core v1.4.1 shipped** with the `on_session_ready` lifecycle hook. amplifier-expert routes ecosystem questions; without the lifecycle in Key Kernel Concepts, researchers asking about module init flow would not see the new optional second hook.
- **`@core:CONTRACTS.md` was missing from Tier 0** — Tier 0 references `@core:docs/` and `@core:docs/specs/` but not the root `CONTRACTS.md`, which is the canonical cross-boundary contract source.
- **Two anti-patterns earned visibility this cycle**:
   - `register_capability` for shared channels — surfaced by foundation PR #182 migration
   - Polluted test env — root cause of the v1.4.0 PyPI yank, documented as release-mandate Incident #5

Adversarial review by `systems-design:systems-design-critic` flagged both new anti-patterns as worth surfacing at the ecosystem-router level so they appear in the routing summary, not just inside the per-domain expert files.

## Scope

`agents/amplifier-expert.md` only. Existing items (1–6) preserved with original numbering; new items appended as 7 and 8.

## Companion PRs

- `microsoft/amplifier-core` — `core-expert.md`, `kernel-overview.md`, `CORE_DEVELOPMENT_PRINCIPLES.md §10`
- `microsoft/amplifier-foundation` — `foundation-expert.md`

## Verification

`git diff --stat main`:
```
 agents/amplifier-expert.md | 4 ++++
 1 file changed, 4 insertions(+)
```

No code changed; no tests required.
