### PR TITLE
docs: register hooks-compact in MODULES.md community hooks catalog

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -290,6 +290,7 @@ Modules built by the community.
 | Module | Description | Author | Repository |
 |--------|-------------|--------|------------|
 | **hooks-concise-display** | Cleaner, more condensed terminal output for Amplifier sessions | [@obra](https://github.com/obra) | [amplifier-module-hooks-concise-display](https://github.com/obra/amplifier-module-hooks-concise-display) |
+| **hooks-compact** | Compress verbose bash stdout via command-aware filters (git, pytest, cargo, npm, ruff, etc.) before it enters the LLM context | [@samueljklee](https://github.com/samueljklee) | [amplifier-module-hooks-compact](https://github.com/samueljklee/amplifier-module-hooks-compact) |
 
 ### Contributing Your Modules
 


### PR DESCRIPTION
## Summary

Adds `hooks-compact` to the community-contributed Hooks section of `docs/MODULES.md`. One-line registry addition.

## What `hooks-compact` is

A `tool:post` hook that compresses verbose bash stdout via command-specific filters before output enters the LLM context window:

- **Conservative on failures:** preserves tracebacks (~30% compression on pytest failure output)
- **Aggressive on passes:** one-line summaries (~98% compression on pytest all-pass)
- **Filters:** git (status/diff/log), pytest, cargo, npm, ruff, eslint, docker, pip, brew, curl
- **User-extensible:** YAML filter definitions at `.amplifier/output-filters.yaml`

Repository: https://github.com/samueljklee/amplifier-module-hooks-compact
Tagged: `v0.1.0-canary.1`

## Validation

6 rounds of DTU testing across the canary readiness sweep:

| Round | Tested | Result |
|-------|--------|--------|
| R1 | Bundle composition + `foundation:bundle` include syntax | ✅ DTU-verified |
| R2 | 8 direct command scenarios + E1 end-to-end | ✅ 9/9 pass, zero regressions |
| R3 | 4 bash-heavy E2E on real ecosystem repos | ✅ 4/4, 94.8% filter compression |
| R4 | Variance measurement (N=4, 24 runs) | ✅ 24/24 correct; session-level effects within LLM noise |
| R5 | Trust-break: bug-fix from compressed tracebacks | ✅ 3/3 success, all bugs fixed correctly |
| R6 | Pinned production tag `v0.1.0-canary.1` | ✅ 5/5 checks pass |

**37 unique `amplifier run` sessions, zero task-correctness regressions.**

## Related Work

- [`microsoft/amplifier-foundation#178`](https://github.com/microsoft/amplifier-foundation/pull/178) — opt-in experiment bundle (`exp-hooks-compact`) for cohort A/B testing. Currently open for review.

This MODULES.md registration is independent of that experiment PR's outcome — the module is published and tagged regardless.

## Why MODULES.md?

The module is the canonical entry point for teammates to discover and adopt `hooks-compact`. Even if the foundation experiment lands, anyone browsing the Amplifier ecosystem registry should be able to find this hook from the catalog.

No code changes outside of `docs/MODULES.md`.