### PR TITLE
docs: register provider-openai-chatgpt in module catalog

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -125,6 +125,7 @@ Connect to AI model providers.
 |--------|-------------|------------|
 | **provider-anthropic** | Anthropic Claude integration (Sonnet 4.5, Opus, etc.) | [amplifier-module-provider-anthropic](https://github.com/microsoft/amplifier-module-provider-anthropic) |
 | **provider-openai** | OpenAI GPT integration | [amplifier-module-provider-openai](https://github.com/microsoft/amplifier-module-provider-openai) |
+| **provider-openai-chatgpt** | ChatGPT subscription backend (Plus/Pro/Team/Enterprise) via Codex CLI OAuth | [amplifier-module-provider-openai-chatgpt](https://github.com/microsoft/amplifier-module-provider-openai-chatgpt) |
 | **provider-azure-openai** | Azure OpenAI with managed identity support | [amplifier-module-provider-azure-openai](https://github.com/microsoft/amplifier-module-provider-azure-openai) |
 | **provider-chat-completions** | OpenAI Chat Completions wire-format integration (llama.cpp, vLLM, LM Studio, LocalAI, etc.) | [amplifier-module-provider-chat-completions](https://github.com/microsoft/amplifier-module-provider-chat-completions) |
 | **provider-gemini** | Google Gemini integration with 1M context and thinking | [amplifier-module-provider-gemini](https://github.com/microsoft/amplifier-module-provider-gemini) |


### PR DESCRIPTION
Registers `provider-openai-chatgpt` in the official Amplifier module catalog.

## Module
[`amplifier-module-provider-openai-chatgpt`](https://github.com/microsoft/amplifier-module-provider-openai-chatgpt)

## What it does
Connects to the ChatGPT subscription backend API using Codex CLI's OAuth device code flow. No API key required — authenticates via the same flow as Codex CLI, working with any ChatGPT Plus, Pro, Team, or Enterprise subscription.

## Available models
- gpt-5.5
- gpt-5.4
- gpt-5.4-mini
- gpt-5.3-codex
- gpt-5.2

## Related work
- Routing matrix integration: https://github.com/microsoft/amplifier-bundle-routing-matrix/pull/18

---
Generated with [Amplifier](https://github.com/microsoft/amplifier)