### PR TITLE
docs(MODULES): add Documentation & Learning category with amplifier-app-learn

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -32,6 +32,16 @@ User-facing applications that compose libraries and modules.
 
 ---
 
+## Documentation & Learning
+
+These are the canonical documentation and learning sites for the Amplifier ecosystem. They reflect the framework but do not run it.
+
+| Component | Description | Repository |
+|-----------|-------------|------------|
+| **amplifier-app-learn** | Interactive learning curriculum for Amplifier — six narrative levels, hands-on approach guides, validated architecture diagrams, and a chat assistant with live DOT rendering. React 19 + Vite SPA. | [amplifier-app-learn](https://github.com/michaeljabbour/amplifier-app-learn) |
+
+---
+
 ## Libraries
 
 Foundational libraries used by **applications** (not used directly by runtime modules).


### PR DESCRIPTION
## What

Adds a new `## Documentation & Learning` section to `docs/MODULES.md` and lists
`amplifier-app-learn` as its first entry.

## Why

`amplifier-app-learn` is the interactive learning site for the framework — a React 19
+ Vite SPA with six narrative levels, hands-on approach guides, validated
architecture diagrams, and a chat assistant with live DOT rendering. It belongs in
MODULES.md so contributors and users can find it from the canonical catalog.

It is not a runtime application — it has no runtime dependency on amplifier-core or
foundation. Putting it in `## Applications` (alongside CLI, amplifierd, log-viewer,
chat, voice, benchmarks) would dilute that section's runtime/operational meaning.
A new `## Documentation & Learning` category leaves room for future learning
surfaces (translations, courses, case-study sites).

## What's not in this PR

- Any change to amplifier-core, foundation, or any module.
- Any change to existing `## Applications` entries.
- The `amplifier-app-learn` repo's contents (hosted separately at the linked URL).

## Validation

Spec is one Markdown table row in one file. No code paths affected.