### PR TITLE
fix(audit): use authenticated gh api for file fetches so audit works on private repos

### DIFF
--- a/recipes/repo-audit.yaml
+++ b/recipes/repo-audit.yaml
@@ -1,6 +1,6 @@
 name: "repo-audit"
 description: "Audit a single Amplifier ecosystem repository for compliance with Microsoft standards and Amplifier guidelines."
-version: "1.4.0"
+version: "1.5.0"
 author: "Amplifier Team"
 tags: ["audit", "compliance", "github", "amplifier"]
 
@@ -189,23 +189,51 @@ steps:
     type: "bash"
     command: |
       TARGET_DIR="{{working_dir}}/{{repo_name}}"
-      BASE_URL="https://raw.githubusercontent.com/{{repo_owner}}/{{repo_name}}/main"
       LOCAL_PATH="{{repo_path}}"
-      
+
       echo "Fetching files from {{repo_owner}}/{{repo_name}}..."
-      
+
+      # Use authenticated `gh api` for content fetching so this works for
+      # BOTH public and private repos. Unauthenticated raw.githubusercontent.com
+      # returns HTTP 404 for private repos even when the file exists, which
+      # would silently misreport every private repo as missing all boilerplate.
+      # Authenticated `gh api` distinguishes:
+      #   - 200 + content : file exists (decode and write)
+      #   - 404           : file truly missing
+      #   - 401/403       : auth/scope problem (loud warning)
       for file in CODE_OF_CONDUCT.md SECURITY.md SUPPORT.md LICENSE README.md; do
-        HTTP_CODE=$(curl -sL --retry 2 -w "%{http_code}" -o "$TARGET_DIR/$file" "$BASE_URL/$file")
-        if [ "$HTTP_CODE" = "200" ] && [ -s "$TARGET_DIR/$file" ]; then
-          echo "$file: found via GitHub ($(wc -c < "$TARGET_DIR/$file") bytes)"
-        elif [ -n "$LOCAL_PATH" ] && [ -f "$LOCAL_PATH/$file" ]; then
-          # Fallback: use local filesystem path (for private repos where unauthenticated curl returns 404)
+        # Capture stderr so we can detect auth failures vs true 404s
+        API_OUT=$(gh api "repos/{{repo_owner}}/{{repo_name}}/contents/$file" 2>&1)
+        API_RC=$?
+
+        if [ "$API_RC" -eq 0 ]; then
+          # Success — decode base64 content
+          echo "$API_OUT" | jq -r '.content' | base64 -d > "$TARGET_DIR/$file" 2>/dev/null
+          if [ -s "$TARGET_DIR/$file" ]; then
+            echo "$file: found via gh api ($(wc -c < "$TARGET_DIR/$file") bytes)"
+            continue
+          fi
+        fi
+
+        # Check if this looks like an auth failure (any private repo whose
+        # owner the user lacks access to, or expired token, or bad scope)
+        if echo "$API_OUT" | grep -qE "(HTTP 401|HTTP 403|Bad credentials|requires authentication|insufficient scopes)"; then
+          echo "$file: AUTH ERROR — gh CLI lacks access to {{repo_owner}}/{{repo_name}}"
+          echo "  Run 'gh auth status' and ensure your token has 'repo' scope and access to this repo."
+          rm -f "$TARGET_DIR/$file"
+          continue
+        fi
+
+        # Local-path fallback (offline / pre-clone case)
+        if [ -n "$LOCAL_PATH" ] && [ -f "$LOCAL_PATH/$file" ]; then
           cp "$LOCAL_PATH/$file" "$TARGET_DIR/$file"
           echo "$file: found via local path ($(wc -c < "$TARGET_DIR/$file") bytes)"
-        else
-          echo "$file: NOT FOUND (HTTP $HTTP_CODE, local path: ${LOCAL_PATH:-not set})"
-          rm -f "$TARGET_DIR/$file"
+          continue
         fi
+
+        # Genuine miss (HTTP 404 with auth proven good by the surrounding context)
+        echo "$file: NOT FOUND (gh api returned non-zero, local path: ${LOCAL_PATH:-not set})"
+        rm -f "$TARGET_DIR/$file"
       done
     output: "target_fetch_result"
     timeout: 120


### PR DESCRIPTION
## Problem

The `fetch-target-files` step in `recipes/repo-audit.yaml` fetches each required Microsoft boilerplate file (`CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, `LICENSE`, `README.md`) via **unauthenticated** `curl` to `https://raw.githubusercontent.com/<owner>/<repo>/main/<file>`.

For **private repos**, `raw.githubusercontent.com` returns HTTP 404 even when the file exists, because anonymous requests cannot read private content. The recipe interprets that 404 as "file missing" and produces a compliance report that silently misreports every private repo as missing all four boilerplate files — even when the files are present and verbatim-correct.

## Real-world impact

Discovered while running `amplifier-ecosystem-audit` against the Microsoft org's 14 private `amplifier-*` repos on 2026-05-03. The audit reported all 14 as missing CODE_OF_CONDUCT.md, SECURITY.md, SUPPORT.md, and LICENSE. After creating fix PRs that copied each file from `microsoft/amplifier-core`, every PR's diff showed only `README.md` changed — meaning the four boilerplate files were already present, already byte-identical to canonical, and the audit's "Missing" finding was a false positive across the entire private-repo set. Today this means anyone running the ecosystem audit on a Microsoft-internal org gets a useless report for the private half of their inventory; tomorrow it means audits run by other teams hit the same trap.

The recipe author had clearly anticipated this — line 46 contains the comment _"e.g. for private repos where unauthenticated curl returns 404"_ and the `repo_path` parameter exists as a local-filesystem fallback. But the parent `amplifier-ecosystem-audit.yaml` and `ecosystem-audit-batch.yaml` recipes never clone repos and never pass `repo_path`, so the fallback never triggers in the multi-repo flow.

## Fix

Replace `curl` to `raw.githubusercontent.com` with `gh api repos/<owner>/<repo>/contents/<file>`. The `gh` CLI is already a hard requirement of this recipe (used everywhere else for issues, PRs, and metadata), so this adds no new dependencies. `gh api` uses the user's existing auth and works transparently for both public and private repos.

The new logic distinguishes three cases that the old logic conflated into one:

| Case | Old behavior | New behavior |
|---|---|---|
| File exists, public repo | Fetched | Fetched (decoded from base64) |
| File exists, private repo (with auth) | **Reported missing** ❌ | Fetched correctly |
| File truly missing | Reported missing | Reported missing |
| Auth failure (bad token, missing scope, no access) | Silently reported as missing ❌ | **Loud `AUTH ERROR` with remediation hint** |

The `$LOCAL_PATH` filesystem fallback is preserved for offline / pre-clone use cases.

## Verification

Smoke-tested the new fetch logic against three scenarios:

```
=== Private repo (microsoft/amplifier-m365): all 5 files fetched ===
  CODE_OF_CONDUCT.md: found via gh api (558 bytes)  — sha256 matches canonical ✓
  SECURITY.md:        found via gh api (542 bytes)  — sha256 matches canonical ✓
  SUPPORT.md:         found via gh api (582 bytes)  — sha256 matches canonical ✓
  LICENSE:            found via gh api (1141 bytes) — sha256 matches canonical ✓
  README.md:          found via gh api (5122 bytes)

=== Public repo (microsoft/amplifier-core): regression check ===
  CODE_OF_CONDUCT.md: found via gh api (558 bytes) ✓
  SECURITY.md:        found via gh api (542 bytes) ✓

=== Genuinely missing file (microsoft/amplifier-core/contents/DOES_NOT_EXIST.md) ===
  rc=1, HTTP 404 — distinguishable from auth errors ✓
```

The hash match against `microsoft/amplifier-core` for the 14 private repos confirms the false positive was systemic: every private repo already had verbatim-correct boilerplate.

## Version

Bumps `version: "1.4.0"` → `version: "1.5.0"` (additive — no breaking changes; existing public-repo audits continue to work; private-repo audits now also work).

## Why this matters

Without this fix, anyone — Microsoft team, partner team, external community — who runs the ecosystem audit against an org with private repos receives a report that systematically misreports compliance state. Worse, it's a silent failure: there's no error indicator, just inaccurate findings. With this fix, anyone with `gh` CLI authenticated and access to the target repos gets accurate results regardless of repo visibility. No per-user setup, no AGENTS.md hacks, no clone-everything-first workaround.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)