### PR TITLE
docs(modules): add taste community bundle

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -257,6 +257,7 @@ Bundles built by the community.
 | **frontdoor** | Authentication gateway and service dashboard for Tailscale-based hosts. Provides PAM-based SSO, Caddy forward_auth integration, and a service discovery dashboard. Includes skills for host infrastructure discovery and web app setup. | [@robotdad](https://github.com/robotdad) | [amplifier-bundle-frontdoor](https://github.com/robotdad/frontdoor) |
 | **codebase-to-course** | Transform any codebase or GitHub URL into a self-contained interactive HTML course for non-technical learners — scroll-based navigation, animated visualizations, embedded quizzes, and code-with-plain-English side-by-side translations | [@johannao76](https://github.com/johannao76) | [amplifier-bundle-codebase-to-course](https://github.com/johannao76/amplifier-bundle-codebase-to-course) |
 
+| **taste** | Anti-slop frontend design discipline with named hard-bans on LLM UI defaults (Inter font, purple-blue gradients, centered heroes, equal-card grids), 3 parametric dials (`DESIGN_VARIANCE` / `MOTION_INTENSITY` / `VISUAL_DENSITY`), 4 mutually-exclusive aesthetic archetypes, and always-on output discipline. Adapted from [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill). | [@michaeljabbour](https://github.com/michaeljabbour) | [amplifier-bundle-taste](https://github.com/michaeljabbour/amplifier-bundle-taste) |
 **Want to share your bundle?** Submit a PR to add your Amplifier bundle to this list!
 
 ---


### PR DESCRIPTION
## Add `taste` community bundle to MODULES.md

This PR adds [`amplifier-bundle-taste`](https://github.com/michaeljabbour/amplifier-bundle-taste), an Amplifier-native adaptation of [`Leonxlnx/taste-skill`](https://github.com/Leonxlnx/taste-skill) (MIT), which provides anti-slop frontend design discipline: named hard-bans on LLM UI defaults (Inter font, purple-blue gradients, centered heroes, equal-card feature grids), three parametric dials (`DESIGN_VARIANCE` / `MOTION_INTENSITY` / `VISUAL_DENSITY`), and four mutually-exclusive aesthetic archetypes (minimalist, brutalist, soft-editorial, GPT-strict).

### What's included
- 8 skills (base + 4 archetype overlays + redesign + design-context-generator + always-on output-discipline)
- 2 specialist agents (`design-critic` for audits, `component-designer` for implementation)
- 3 recipes (`image-to-code`, `redesign-audit`, `design-system-bootstrap`)
- 1 always-on behavior (`output-discipline`) — domain-agnostic, useful beyond frontend work

### Attribution

All substantive design rules (the parametric dials, named bans, archetype palettes, the Bento 2.0 paradigm, the Doppelrand pattern, the image-to-code workflow, the research-backed output discipline) are [Leonxlnx](https://github.com/Leonxlnx)'s original work. This adaptation reformats those skills into Amplifier bundle/skill/behavior/recipe conventions without modifying the substantive design guidance. Users of this bundle are asked to **star the upstream repo** and credit Leonxlnx — see `LICENSE` and `README.md` in the adapted bundle for the full attribution.

### Quality

- v0.3.0 tagged and released (3 expert review passes, 2 critical correctness bug fixes, full context-sink extraction, GitHub Actions bundle validation)
- All YAML parses, all `@taste:` cross-references resolve, all skill/agent frontmatters valid
- Pure-Markdown content bundle — no Python module dependencies

### Checklist for reviewer

- [x] Bundle is publicly accessible
- [x] LICENSE present and matches upstream (MIT)
- [x] Attribution to upstream prominent in README
- [x] Bundle YAML parses cleanly
- [x] No Python modules running arbitrary code at load time
- [x] Versioned (v0.3.0 tagged)
