### PR TITLE
docs: list amplifier-eval-harness in MODULES.md

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -22,6 +22,7 @@ User-facing applications that compose libraries and modules.
 |-----------|-------------|------------|
 | **amplifier** | Main Amplifier project and entry point - installs amplifier-app-cli via `uv tool install` | [amplifier](https://github.com/microsoft/amplifier) |
 | **amplifier-app-cli** | Reference CLI application implementing the Amplifier platform | [amplifier-app-cli](https://github.com/microsoft/amplifier-app-cli) |
+| **amplifier-eval-harness** | Configurable test harness for evaluating Amplifier bundles across scenarios and providers in isolated Digital Twin Universe environments. Captures wall time, LLM time, per-call tokens, cache traffic, request counts, and per-`provider/model` breakdowns across the full session tree (parent + every sub-session) for cross-bundle and cross-provider comparison. | [amplifier-eval-harness](https://github.com/microsoft/amplifier-eval-harness) |
 | **amplifier-app-log-viewer** | Web-based log viewer for debugging sessions with real-time updates | [amplifier-app-log-viewer](https://github.com/microsoft/amplifier-app-log-viewer) |
 | **amplifier-app-benchmarks** | Benchmarking and evaluating Amplifier | [amplifier-app-benchmarks](https://github.com/DavidKoleczek/amplifier-app-benchmarks) |
 | **amplifierd** | Localhost HTTP daemon exposing amplifier-core and amplifier-foundation over REST and SSE - drive sessions from any language or framework | [amplifierd](https://github.com/microsoft/amplifierd) |


### PR DESCRIPTION
## Summary

Adds a `MODULES.md` listing for `microsoft/amplifier-eval-harness` under the **Applications** section. The repo was recently moved from a personal namespace into the `microsoft` org and brought up to Microsoft OSS file compliance via `recipes/repo-audit.yaml`. The audit recommended listing it for ecosystem discoverability — this PR closes that recommendation.

## What it is

`amplifier-eval-harness` is a configurable test harness for evaluating Amplifier bundle configurations across scenarios + LLM providers in isolated Digital Twin Universe environments. It captures wall time, LLM time, per-call tokens, cache traffic, request counts, and per-`provider/model` breakdowns across the full session tree (parent + every sub-session spawned via delegate / recipes / fork-skills).

## Test plan

- [x] MODULES.md still parses cleanly (markdown table intact)
- [x] Insertion is alphabetically reasonable in the Applications section (between `amplifier-app-cli` and `amplifier-app-log-viewer`)
- [x] Repo URL resolves and points at the correct repo

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)