### PR TITLE
docs: add amplifier-app-actions to MODULES.md

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -21,6 +21,7 @@ User-facing applications that compose libraries and modules.
 | Component | Description | Repository |
 |-----------|-------------|------------|
 | **amplifier** | Main Amplifier project and entry point - installs amplifier-app-cli via `uv tool install` | [amplifier](https://github.com/microsoft/amplifier) |
+| **amplifier-app-actions** | AI-powered GitHub Actions for automated issue triage and PR review | [amplifier-app-actions](https://github.com/microsoft/amplifier-app-actions) |
 | **amplifier-app-cli** | Reference CLI application implementing the Amplifier platform | [amplifier-app-cli](https://github.com/microsoft/amplifier-app-cli) |
 | **amplifier-app-log-viewer** | Web-based log viewer for debugging sessions with real-time updates | [amplifier-app-log-viewer](https://github.com/microsoft/amplifier-app-log-viewer) |
 | **amplifier-app-benchmarks** | Benchmarking and evaluating Amplifier | [amplifier-app-benchmarks](https://github.com/DavidKoleczek/amplifier-app-benchmarks) |


### PR DESCRIPTION
Registers `microsoft/amplifier-app-actions` in the ecosystem catalog.

AI-powered GitHub Actions for automated issue triage and PR review — drop-in action for any private repo.

Repo: https://github.com/microsoft/amplifier-app-actions

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>