### PR TITLE
docs(modules): register amplifier-bundle-llm-wiki in MODULES.md

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -60,6 +60,7 @@ Composable configuration packages that combine providers, behaviors, agents, and
 | **gitea** | On-demand ephemeral Gitea instances for isolated git workflows — mirror repos from GitHub, work freely, and promote results back when ready | [amplifier-bundle-gitea](https://github.com/microsoft/amplifier-bundle-gitea) |
 | **foreman** | Assistant pattern where the conversation assistant manages a fleet of other assistants, each with their own sessions, leveraging capabilities from amplifier-bundle-orchestration | [amplifier-bundle-foreman](https://github.com/payneio/amplifier-bundle-foreman) |
 | **issues** | Persistent issue tracking with dependency management, priority scheduling, and session linking for autonomous work | [amplifier-bundle-issues](https://github.com/microsoft/amplifier-bundle-issues) |
+| **llm-wiki** | Karpathy LLM Wiki pattern as composable workflow modes — wiki-init, wiki-ingest, wiki-lint, wiki-publish, wiki-query; zero-cost-when-dormant via per-mode shared orientation | [amplifier-bundle-llm-wiki](https://github.com/microsoft/amplifier-bundle-llm-wiki) |
 | **lsp** | Core Language Server Protocol support for code intelligence operations | [amplifier-bundle-lsp](https://github.com/microsoft/amplifier-bundle-lsp) |
 | **lsp-python** | DEPRECATED — forwarding stub, use python-dev instead | [amplifier-bundle-lsp-python](https://github.com/microsoft/amplifier-bundle-lsp-python) |
 | **lsp-rust** | DEPRECATED — forwarding stub, use rust-dev instead | [amplifier-bundle-lsp-rust](https://github.com/microsoft/amplifier-bundle-lsp-rust) |


### PR DESCRIPTION
## Summary

Adds a Bundles-section entry for the newly-published [`microsoft/amplifier-bundle-llm-wiki`](https://github.com/microsoft/amplifier-bundle-llm-wiki), inserted alphabetically between `issues` and `lsp`.

This bundle implements the [Karpathy LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) as five composable workflow modes:

| Mode | Purpose |
|---|---|
| `/wiki-init` | Design and scaffold the project-specific policy (schema, publish target, viewer) |
| `/wiki-ingest` | Process raw content from `raw/` into the wiki |
| `/wiki-lint` | Read-only health check — orphans, stale refs, contradictions, broken cross-refs |
| `/wiki-publish` | Generate the shippable artifact via the project's publish script |
| `/wiki-query` | Read-only Q&A against the compiled wiki |

Uses the zero-cost-when-dormant pattern (documented as the canonical multi-mode shared-orientation reference implementation in [`amplifier-bundle-modes` schema reference §9.7](https://github.com/microsoft/amplifier-bundle-modes/blob/main/context/mode-schema-reference.md#97-workflow-modes-with-shared-orientation), landed earlier this session as PR #23).

## Why

The bundle just went through `@amplifier:recipes/repo-audit.yaml` v1.7.0 → audit PASS with zero errors and zero warnings; this PR closes the one remaining "Recommendation" finding ("Listed in MODULES.md") that was deliberately scoped to a separate repo.

## Audit status of the bundle being registered

`microsoft/amplifier-bundle-llm-wiki` audit summary after the recent migration and cleanup work:

- ✅ All four boilerplate files match canonical (LICENSE, CODE_OF_CONDUCT.md, SECURITY.md, SUPPORT.md)
- ✅ README Contributing + Trademarks verbatim match
- ✅ Issues / Wiki / Projects disabled
- ✅ Branch protection ruleset (`amplifier-default-branch-protection`) active on `main` with PR review, linear history, no force-push, no delete
- ✅ Bypass actors and PR rule strictness match canonical `amplifier-*` configuration

## Test plan

- [x] Change is a single-line addition to the alphabetically-sorted Bundles table
- [x] No other files affected
- [x] The new entry follows the existing row format (`| **name** | description | [repo-link](url) |`) exactly
- [x] Entry inserted between `issues` (line 62) and `lsp` (line 63) in alphabetical order