### PR TITLE
docs: remove dead amplifier-app-learn entry from MODULES.md

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -48,7 +48,6 @@ These are the canonical documentation and learning sites for the Amplifier ecosy
 
 | Component | Description | Repository |
 |-----------|-------------|------------|
-| **amplifier-app-learn** | Interactive learning curriculum for Amplifier — six narrative levels, hands-on approach guides, validated architecture diagrams, and a chat assistant with live DOT rendering. React 19 + Vite SPA. | [amplifier-app-learn](https://github.com/michaeljabbour/amplifier-app-learn) |
 | **amplifier-docs** | Documentation for the Amplifier project | [amplifier-docs](https://github.com/microsoft/amplifier-docs) |
 
 ---


### PR DESCRIPTION
The michaeljabbour/amplifier-app-learn repository returns HTTP 404, making this entry stale. The entry was added in #279.

Only the dead row is removed now — the 'Documentation & Learning' section is retained with amplifier-docs, which remains live and current. This narrowed change replaces the original #309 which would have deleted the entire section (which was appropriate before amplifier-docs was added to it, but not anymore).

The repository can be restored if it becomes available again.