### PR TITLE
docs: add aiuser to component catalog

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -55,6 +55,7 @@ Foundational libraries used by **applications** (not used directly by runtime mo
 | Component | Description | Repository |
 |-----------|-------------|------------|
 | **amplifier-foundation** | Foundational library for bundles, module resolution, and shared utilities | [amplifier-foundation](https://github.com/microsoft/amplifier-foundation) |
+| **aiuser** | Reusable "AI User" that drives a lower-level AI session toward a goal across multiple turns given a persona, scenario, and invocation guide, then reports a verdict — built to be embedded for testing and evaluation. | [amplifier-bundle-aiuser](https://github.com/microsoft/amplifier-bundle-aiuser) |
 
 **Architectural Boundary**: Libraries are consumed by applications (like amplifier-app-cli). Runtime modules only depend on amplifier-core and never use these libraries directly.
 


### PR DESCRIPTION
## Summary

Adds the **aiuser** entry to `docs/MODULES.md`.

`aiuser` is a reusable "AI User" that drives a lower-level AI session toward a goal across multiple turns given a persona, scenario, and invocation guide, then reports a verdict — built to be embedded for testing and evaluation.

## Placement

Added to the **Libraries** section rather than **Bundles**. Despite the `amplifier-bundle-aiuser` repo name, it currently ships as the `amplifier_aiuser` Python package (imported, not composed via `amplifier bundle add` / `include:`), so Libraries is the accurate placement.

Repo: https://github.com/microsoft/amplifier-bundle-aiuser

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)