### PR TITLE
docs: remove dead amplifier-app-learn link from MODULES.md

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -48,7 +48,6 @@ These are the canonical documentation and learning sites for the Amplifier ecosy
 
 | Component | Description | Repository |
 |-----------|-------------|------------|
-| **amplifier-app-learn** | Interactive learning curriculum for Amplifier — six narrative levels, hands-on approach guides, validated architecture diagrams, and a chat assistant with live DOT rendering. React 19 + Vite SPA. | [amplifier-app-learn](https://github.com/michaeljabbour/amplifier-app-learn) |
 | **amplifier-docs** | Documentation for the Amplifier project | [amplifier-docs](https://github.com/microsoft/amplifier-docs) |
 
 ---


### PR DESCRIPTION
## Summary
- Removes the **amplifier-app-learn** row from the Documentation & Learning table: the linked repository (michaeljabbour/amplifier-app-learn) returns HTTP 404 (verified 2026-08-02 via `gh api repos/michaeljabbour/amplifier-app-learn`).

## Test plan
- Doc-only change; `git diff --stat` = 1 file, 1 deletion. Verified no other reference to amplifier-app-learn remains in docs/MODULES.md.

Generated with [Amplifier](https://github.com/microsoft/amplifier)