### PR TITLE
docs: add jilog to Community Applications

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -270,6 +270,7 @@ Applications built by the community using Amplifier.
 | **amplifier-playground** | Interactive environment for building, configuring, and testing Amplifier AI agent sessions | [@samueljklee](https://github.com/samueljklee) | [amplifier-playground](https://github.com/samueljklee/amplifier-playground) |
 | **amplifier-lakehouse** | Amplifier on top of your data (daemon and webapp) | [@payneio](https://github.com/payneio) | [amplifier-lakehouse](https://github.com/payneio/lakehouse) |
 | **app-session-analyzer** | Analyze Amplifier session logs and generate interesting metrics about your usage! | [@DavidKoleczek](https://github.com/DavidKoleczek) | [amplifier-app-session-analyzer](https://github.com/DavidKoleczek/amplifier-app-session-analyzer) |
+| **jilog** | Append-only event ledger and nightly learning loop over Amplifier, Claude Code, and NanoClaw session transcripts — surfaces corrections, workarounds, and recurring patterns, files tracker issues, and checks whether the system actually improved | [@Joi](https://github.com/Joi) | [jilog](https://github.com/Joi/jilog) |
 
 **Want to showcase your application?** Submit a PR to add your Amplifier-powered application to this list!
 


### PR DESCRIPTION
## Summary
- Responds to the "Want to showcase your application?" invitation in the Community Applications section: adds one row for **jilog** — an append-only event ledger and nightly learning loop over Amplifier, Claude Code, and NanoClaw session transcripts.
- Repo: https://github.com/Joi/jilog — MIT, Rust, v0.4.0, production-tested on the author's fleet (its built-in Amplifier reader scans session transcripts nightly).

## Test plan
- Doc-only change; `git diff --stat` = 1 file, 1 insertion. Row follows the existing table format (matches the app-session-analyzer precedent row).

Generated with [Amplifier](https://github.com/microsoft/amplifier)