### PR TITLE
docs: add android-tester bundle to ecosystem index

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -75,6 +75,7 @@ Composable configuration packages that combine providers, behaviors, agents, and
 |--------|-------------|------------|
 | **a2a** | Agent-to-Agent communication via Google's A2A protocol — discovery, trust, message routing across Amplifier sessions | [amplifier-bundle-a2a](https://github.com/microsoft/amplifier-bundle-a2a) |
 | **amplifier-tester** | Validates Amplifier ecosystem changes (core, modules, bundles, foundation, app-cli) in isolated Digital Twin Universe environments — dynamically generates profiles, mirrors repos to Gitea, and runs targeted validation checks | [amplifier-bundle-amplifier-tester](https://github.com/microsoft/amplifier-bundle-amplifier-tester) |
+| **android-tester** | Android app testing on emulators and devices — 3 specialist agents (operator, visual-tester, debugger) driving apps via the accessibility tree with screenshot-based visual verification, plus emulator provisioning and host diagnostics | [amplifier-bundle-android-tester](https://github.com/microsoft/amplifier-bundle-android-tester) |
 | **attractor** | Attractor pipeline orchestration | [amplifier-bundle-attractor](https://github.com/microsoft/amplifier-bundle-attractor) |
 | **browser-tester** | Browser automation and testing with 3 specialized agents (operator, researcher, visual documenter) using agent-browser CLI | [amplifier-bundle-browser-tester](https://github.com/microsoft/amplifier-bundle-browser-tester) |
 | **containers** | Container-based execution environments | [amplifier-bundle-containers](https://github.com/microsoft/amplifier-bundle-containers) |


### PR DESCRIPTION
## Summary

Adds the android-tester bundle to the ecosystem MODULES.md index.

The `repo-audit` recipe flagged `amplifier-bundle-android-tester` as missing from the MODULES.md catalog. Unlisted repositories are invisible to anyone browsing the bundle ecosystem and to agents that mine MODULES.md for repo discovery.

## What This Adds

The **android-tester** bundle provides emulator-driven Android UI testing with:
- 3 specialist agents: operator, visual-tester, debugger
- Accessibility tree-based app control
- Screenshot-based visual verification
- Emulator provisioning and host diagnostics

## Placement

Added in alphabetical order between **amplifier-tester** and **attractor** bundles, matching the existing table format with no other changes to MODULES.md.