### PR TITLE
docs: add amplifier-browser-bridge to ecosystem index

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -37,6 +37,7 @@ User-facing applications that compose libraries and modules.
 | **amplifier-voice** | Voice plugin for amplifierd - WebRTC voice interface using the OpenAI Realtime API, standalone or as a plugin | [amplifier-voice](https://github.com/microsoft/amplifier-voice) |
 | **amplifier-app-aiuser** | Reusable "AI User" that drives a lower-level AI session toward a goal across multiple turns given a persona, scenario, and invocation guide, then reports a verdict — built to be embedded for testing and evaluation. | [amplifier-app-aiuser](https://github.com/microsoft/amplifier-app-aiuser) |
 | **amplifier-app-openclaw** | OpenClaw skill for the Amplifier project | [amplifier-app-openclaw](https://github.com/microsoft/amplifier-app-openclaw) |
+| **amplifier-browser-bridge** | Lets an agent running on one machine drive the user's real, logged-in Microsoft Edge browser on other devices — desktop or Android — over their own Tailscale network, with no third-party relay | [amplifier-browser-bridge](https://github.com/microsoft/amplifier-browser-bridge) |
 
 **Note**: When you install `amplifier`, you get the amplifier-app-cli as the executable application. `amplifierd` is a separate daemon that exposes Amplifier capabilities over HTTP, and `amplifier-chat` and `amplifier-voice` are plugins that extend it with web-based chat and voice interfaces.
 


### PR DESCRIPTION
Adds `amplifier-browser-bridge` to the Applications table in `docs/MODULES.md`.

**What it is:** an agent running on one machine drives the user's real, logged-in Microsoft Edge browser on *other* devices — desktop or Android — over their own Tailscale network, with no third-party relay.

**Why Applications and not Bundles:** the repo ships a hub daemon, a browser extension, a CLI, an MCP server and an Amplifier tool module. It is a user-facing application that composes modules, not a configuration package. (`amplifierd`, `amplifier-chat` and `amplifier-voice` are listed the same way.)

**Context:** the repo was published to `microsoft/amplifier-browser-bridge` today with its full history. A `repo-audit` run flagged "Listed in MODULES.md — Fail (recommendation)"; this PR closes that finding.

Docs-only change — one table row, no code touched.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)