### PR TITLE
fix: ecosystem audit crashes in check-repo-limit due to shell quoting bug

### DIFF
--- a/recipes/amplifier-ecosystem-audit.yaml
+++ b/recipes/amplifier-ecosystem-audit.yaml
@@ -261,17 +261,31 @@ stages:
         parse_json: true
         command: |
           MAX_REPOS={{max_repos}}
+          ALL_REPOS_FILE="{{working_dir}}/all_repos.json"
           
-          # Debug: Check what we received
-          echo "DEBUG: all_repos variable length: ${#ALL_REPOS_RAW}" >&2
+          # Read the repo list from disk. The preceding merge-repo-lists step
+          # already wrote this file, so there is no need to interpolate the
+          # JSON blob into the shell -- and doing so is unsafe. Repo
+          # descriptions are free text from the GitHub API and routinely
+          # contain apostrophes, which terminate a single-quoted shell string
+          # and break the surrounding command substitution.
+          if [ ! -s "$ALL_REPOS_FILE" ]; then
+            echo "ERROR: missing or empty $ALL_REPOS_FILE" >&2
+            jq -n --argjson max "$MAX_REPOS" '{
+              exceeded: false,
+              total: 0,
+              max: $max,
+              error: "No repositories found"
+            }'
+            exit 1
+          fi
           
-          # Get total from all_repos - handle empty/malformed gracefully
-          TOTAL=$(echo '{{all_repos}}' | jq -r '.total // 0' 2>/dev/null || echo "0")
+          TOTAL=$(jq -r '.total // 0' "$ALL_REPOS_FILE" 2>/dev/null || echo "0")
           
           # Validate TOTAL is a number
           if ! [[ "$TOTAL" =~ ^[0-9]+$ ]]; then
-            echo "ERROR: Could not parse repo count from all_repos. Got: '$TOTAL'" >&2
-            echo "all_repos content preview: $(echo '{{all_repos}}' | head -c 200)" >&2
+            echo "ERROR: Could not parse repo count from $ALL_REPOS_FILE. Got: '$TOTAL'" >&2
+            head -c 200 "$ALL_REPOS_FILE" >&2
             TOTAL=0
           fi
           


### PR DESCRIPTION
## Problem

The `amplifier-ecosystem-audit` recipe is currently broken and unrunnable. Every ecosystem audit execution fails at the `check-repo-limit` step with a bash syntax error:

```
Step 'check-repo-limit': command failed with exit code 2
/bin/bash: -c: line 6: unexpected EOF while looking for matching `)`
/bin/bash: -c: line 44: syntax error: unexpected end of file
```

This failure occurs before the discovery approval gate, so no per-repo audits run and no report is generated. The ecosystem audit is blocked for all users.

## Root Cause

The `check-repo-limit` step interpolated the entire discovered-repo JSON blob (~36KB) directly into a bash command inside single quotes, in two locations:
- `TOTAL=$(echo '{{all_repos}}' | jq -r '.total // 0' ...)`
- `echo "all_repos content preview: $(echo '{{all_repos}}' | head -c 200)" >&2`

Repo descriptions are sourced from the GitHub API as free text. Three repositories in the Microsoft org currently have apostrophes in their descriptions:
- `amplifier-bundle-alexa-tester`: "...against Amazon**'**s real NLU"
- `amplifier-collections`: "Reference implementation of a collection**'**s library..."
- `amplifier-profiles`: "Reference implementation for a profile**'**s library..."

In bash, an apostrophe inside single quotes terminates the quoted string. When the JSON blob containing "Amazon's" is pasted into the middle of the quoted command, bash interprets the apostrophe as the end of the quoted string. The remaining 30+ KB of JSON is then parsed as shell syntax, the command substitution is never closed, and the parser fails.

This is deterministic and reproducible — not an intermittent failure. It will block every ecosystem audit run until fixed, for any organization whose repos contain apostrophes in their descriptions.

## Solution

Stop interpolating the JSON blob into the shell. The immediately preceding step (`merge-repo-lists`) already writes the identical data to `{{working_dir}}/all_repos.json` via `tee`. The fixed step now reads that file directly with `jq`:

```bash
TOTAL=$(jq -r '.total // 0' "$ALL_REPOS_FILE" 2>/dev/null || echo "0")
```

This approach:
- Eliminates the bug class entirely — no externally-sourced text is interpolated into the shell
- Removes a latent shell-injection surface (repo descriptions are attacker-influencable)
- Keeps the fix reviewable and focused

As a non-blocking follow-up, three other single-quoted interpolations remain in the file at lines with `MANUAL_REPOS`, `INCLUDE_COMMUNITY`, and `WORKING_DIR`. The first two are low-risk (constrained values), but `WORKING_DIR` would break on paths containing apostrophes. These are left unchanged in this PR.

Also removed a bogus debug line referencing `${#ALL_REPOS_RAW}`, a variable that was never set and printed "length: 0" on every run, actively misleading diagnosis.

## Verification

The patched `check-repo-limit` step was extracted and executed against four scenarios:

| Scenario | Input | Expected | Result | Status |
|----------|-------|----------|--------|--------|
| Production data (135 repos, incl. apostrophes) | Real discovery output with Amazon's / collection's / profile's descriptions | exit 0, `{"exceeded": false, "total": 135, "max": 1000}` | ✓ PASS | ✓ |
| Over-limit safety brake | max_repos=10 vs discovered total=135 | exit 1, `{"exceeded": true, "total": 135, "max": 10, "error": "...safety limit"}` | ✓ PASS | ✓ |
| Missing file guard | `all_repos.json` absent or empty | exit 1, `{"total": 0, ..., "error": "No repositories found"}` | ✓ PASS | ✓ |
| Adversarial description | Description with `'; touch /tmp/PWNED; '`, `$(id)`, backticks, double quotes | exit 0, parsed normally, no injection executed | ✓ PASS | ✓ |

Also confirmed the full YAML still parses (`yaml.safe_load`) and the recipe version is unchanged at 2.1.0.