### PR TITLE
docs: list windows-shell bundle in MODULES.md

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -126,6 +126,7 @@ Composable configuration packages that combine providers, behaviors, agents, and
 | **typescript-dev** | TypeScript development tools (linting, type checking, LSP) | [amplifier-bundle-typescript-dev](https://github.com/microsoft/amplifier-bundle-typescript-dev) |
 | **webllm** | WebLLM with WebGPU for running amplifier-core in browsers | [amplifier-bundle-webllm](https://github.com/microsoft/amplifier-bundle-webllm) |
 | **webruntime** | Web runtime for browser-based Amplifier | [amplifier-bundle-webruntime](https://github.com/microsoft/amplifier-bundle-webruntime) |
+| **windows-shell** | Native Windows shell support — the `pwsh` tool with pinned UTF-16LE payload encoding, a stdin-gated Win32 Job Object, and PowerShell-shaped safety profiles matching tool-bash's config surface | [amplifier-bundle-windows-shell](https://github.com/microsoft/amplifier-bundle-windows-shell) |
 | **work-tracker** | Multi-agent work coordination — atomic claiming so exactly one agent ever holds an item, PID-bound custody that survives long autonomous and long idle holds, feedback routed back to whoever reported it, and an executable contract suite that makes storage-layer churn fail loudly. Built on Beads. | [amplifier-work-tracker](https://github.com/microsoft/amplifier-work-tracker) |
 
 **Usage**: Bundles are loaded via the `amplifier bundle` commands:


### PR DESCRIPTION
Adds `microsoft/amplifier-bundle-windows-shell` to the bundles catalog.

The `repo-audit` recipe flagged the bundle as unlisted, which makes it undiscoverable to anyone browsing `MODULES.md`. Inserted alphabetically between `webruntime` and `work-tracker`.

## What the bundle provides

Native Windows shell support — a `pwsh` tool for PowerShell execution. Amplifier's `bash` tool is the largest tool surface in the product; on Windows it resolves to WSL bash, Git Bash, or nothing.

## Verification

The bundle itself is proven on native Windows 11 (build 26200): **185 tests pass, 0 skipped**, including 14 live-execution tests confirmed to have actually run against both `pwsh` 7 and `powershell` 5.1 — counted, not inferred from a green summary.

That distinction matters here. The Linux suite was green at 171 passed while two real bugs were live — output encoding pinned in only one direction, and `$?` read in a position where it reports the scriptblock invocation rather than the user's command. Running on real Windows found both.

`foundation:recipes/validate-bundle-repo.yaml` returns **PASS** — 0 errors, 0 warnings.

## Scope

Docs only — one row in `docs/MODULES.md`. No code, no behavior change.