### PR TITLE
recipes: migrate to schema v2 dependency manifests (6 of 7)

### DIFF
--- a/recipes/amplifier-ecosystem-audit.yaml
+++ b/recipes/amplifier-ecosystem-audit.yaml
@@ -1,6 +1,34 @@
+# --- Dependency manifest (contract: recipe-dependency-manifest.v1) ----------
+# schema_version 2 makes this recipe portable: every `agent:` reference below
+# resolves ONLY from the declared closure here, never from the calling
+# session's agent map. A caller that lacks these agents can still run it.
+# Pinned to the released tag `v2.1.2`. Foundation fetches a ref with
+# `git clone --branch`, which accepts a branch or a tag but NOT a commit SHA,
+# so a tag is the most immutable pin a `source:` can currently express.
+#
+# v2.2.0 -- this block is the only change. Previously the
+# `agent: "foundation:zen-architect"` steps below resolved out of the CALLING
+# session's agent map; a caller without that agent failed at run time with
+# "Agent 'foundation:zen-architect' not found in configuration". They now
+# resolve from this recipe's own declared closure. No behavior change under
+# the legacy engine, which ignores both new top-level keys. Recipe logic,
+# steps and prompts untouched.
+#
+# NOTE: the sub-recipes this recipe invokes (`ecosystem-audit-batch.yaml`,
+# `repo-audit.yaml`) carry their own manifests -- a sub-recipe's closure is
+# its own, not inherited from here.
+schema_version: 2
+
+dependencies:
+  - source: "git+https://github.com/microsoft/amplifier-foundation@v2.1.2"
+    kind: bundle
+    required_agents:
+      - "foundation:zen-architect"
+# ---------------------------------------------------------------------------
+
 name: "amplifier-ecosystem-audit"
 description: "Audit all Amplifier ecosystem repositories (public and private) in the Microsoft GitHub organization for compliance. Uses a batched architecture (configurable batch_size, default 25) with public/private separation; scales past 100 repos and supports the audit_visibility filter. Aggregates per-repo Dependabot open-PR findings to the top-level report as always-reported warnings."
-version: "2.1.0"
+version: "2.2.0"
 author: "Amplifier Team"
 tags: ["audit", "compliance", "github", "amplifier", "ecosystem", "multi-repo"]
 

--- a/recipes/document-generation.yaml
+++ b/recipes/document-generation.yaml
@@ -52,6 +52,25 @@
 # CHANGELOG
 # =============================================================================
 #
+# v8.2.0 (2026-09-02):
+#   - PORTABILITY: declare a schema_version 2 dependency manifest
+#     (contract recipe-dependency-manifest.v1; block sits above `name:`)
+#     * The `foundation:explorer` / `foundation:zen-architect` /
+#       `design-intelligence:layout-architect` /
+#       `design-intelligence:voice-strategist` steps below previously resolved
+#       out of the CALLING session's agent map; a caller without them failed at
+#       run time with "Agent 'design-intelligence:voice-strategist' not found
+#       in configuration"
+#     * They now resolve from this recipe's own declared closure
+#     * ONE dependency covers all four: foundation composes
+#       amplifier-bundle-design-intelligence via its own bundle.md include.
+#       Declaring design-intelligence separately collides (both bundles supply
+#       the same agent names) -- see the note on the manifest block
+#     * The "Requirements: foundation bundle" line in the header above is now
+#       enforced by the manifest rather than left to the caller
+#   - No behavior change under the legacy engine, which ignores both new
+#     top-level keys. Recipe logic, steps and prompts untouched.
+#
 # v8.1.0 (2026-01-30):
 #   - NEW FEATURE: Design Intelligence Feedback (EXPERIMENTAL)
 #     * Adds observational feedback from DI agents at TWO stages:
@@ -253,9 +272,41 @@
 #
 # =============================================================================
 
+# --- Dependency manifest (contract: recipe-dependency-manifest.v1) ----------
+# schema_version 2 makes this recipe portable: every `agent:` reference below
+# resolves ONLY from the declared closure here, never from the calling
+# session's agent map. A caller that lacks these agents can still run it.
+# Pinned to the released tag `v2.1.2`. Foundation fetches a ref with
+# `git clone --branch`, which accepts a branch or a tag but NOT a commit SHA,
+# so a tag is the most immutable pin a `source:` can currently express.
+#
+# ONE dependency, not two, even though this recipe references BOTH the
+# `foundation:` and `design-intelligence:` namespaces. The foundation bundle
+# composes amplifier-bundle-design-intelligence via its own `bundle.md`
+# include, so the single source below genuinely supplies all four agents --
+# verified, not assumed: the planner's `required_agents` preflight fails loud
+# if a declared dependency does not actually supply a name listed under it.
+# Declaring amplifier-bundle-design-intelligence as a SECOND dependency was
+# tried and is wrong: that bundle composes foundation too, so the two sources
+# supply overlapping agent names and planning aborts with
+# AgentCollisionError ("Agent name 'amplifier:amplifier-expert' is supplied by
+# more than one dependency").
+schema_version: 2
+
+dependencies:
+  - source: "git+https://github.com/microsoft/amplifier-foundation@v2.1.2"
+    kind: bundle
+    required_agents:
+      - "foundation:explorer"
+      - "foundation:zen-architect"
+      # Supplied by foundation's design-intelligence include (see note above).
+      - "design-intelligence:layout-architect"
+      - "design-intelligence:voice-strategist"
+# ---------------------------------------------------------------------------
+
 name: "document-generation"
 description: "Generate documentation from an outline with BFS traversal, parallel validation, provider preferences, and Design Intelligence feedback"
-version: "8.1.0"
+version: "8.2.0"
 author: "Amplifier Recipes Collection"
 tags: ["documentation", "generation", "outline", "bfs", "validation", "staged", "resumable", "parallel"]
 

--- a/recipes/ecosystem-activity-report.yaml
+++ b/recipes/ecosystem-activity-report.yaml
@@ -1,6 +1,24 @@
+# --- Dependency manifest (contract: recipe-dependency-manifest.v1) ----------
+# schema_version 2 makes this recipe portable: every `agent:` reference below
+# resolves ONLY from the declared closure here, never from the calling
+# session's agent map. A caller that lacks these agents can still run it.
+# Pinned to the released tag `v2.1.2`. Foundation fetches a ref with
+# `git clone --branch`, which accepts a branch or a tag but NOT a commit SHA,
+# so a tag is the most immutable pin a `source:` can currently express.
+schema_version: 2
+
+dependencies:
+  - source: "git+https://github.com/microsoft/amplifier-foundation@v2.1.2"
+    kind: bundle
+    required_agents:
+      - "foundation:explorer"
+      - "foundation:file-ops"
+      - "foundation:zen-architect"
+# ---------------------------------------------------------------------------
+
 name: "ecosystem-activity-report"
 description: "Analyze activity across the Amplifier ecosystem by discovering repos from MODULES.md"
-version: "1.15.2"
+version: "1.16.0"
 author: "Amplifier"
 tags: ["amplifier", "ecosystem", "github", "activity", "modules", "discovery"]
 
@@ -14,6 +32,20 @@ tags: ["amplifier", "ecosystem", "github", "activity", "modules", "discovery"]
 # 3. Reads MODULES.md to discover all ecosystem repos
 # 4. Filters repos based on criteria (org, name pattern)
 # 5. Calls the generic multi-repo recipe from @recipes bundle
+#
+# v1.16.0: Portability - declare a schema_version 2 dependency manifest
+#         (contract recipe-dependency-manifest.v1, block at top of file)
+#         - The `agent: "foundation:explorer"` / `"foundation:file-ops"` /
+#           `"foundation:zen-architect"` steps below previously resolved out of
+#           the CALLING session's agent map; a caller without them failed at
+#           run time with "Agent 'foundation:file-ops' not found in
+#           configuration"
+#         - They now resolve from this recipe's own declared closure
+#         - The sub-recipe this recipe delegates to (repo-activity-analysis)
+#           carries its own manifest; a sub-recipe's closure is its own, not
+#           inherited from here
+#         - No behavior change under the legacy engine, which ignores both new
+#           top-level keys. Recipe logic, steps and prompts untouched.
 #
 # v1.15.2: Fix reduce-analyses step to filter intermediate files
 #         - Same fix as v1.15.1 but for reduce-analyses step (was missed)

--- a/recipes/outline-generation-from-doc.yaml
+++ b/recipes/outline-generation-from-doc.yaml
@@ -23,15 +23,45 @@
 #
 # =============================================================================
 
+# --- Dependency manifest (contract: recipe-dependency-manifest.v1) ----------
+# schema_version 2 makes this recipe portable: every `agent:` reference below
+# resolves ONLY from the declared closure here, never from the calling
+# session's agent map. A caller that lacks these agents can still run it.
+# Pinned to the released tag `v2.1.2`. Foundation fetches a ref with
+# `git clone --branch`, which accepts a branch or a tag but NOT a commit SHA,
+# so a tag is the most immutable pin a `source:` can currently express.
+schema_version: 2
+
+dependencies:
+  - source: "git+https://github.com/microsoft/amplifier-foundation@v2.1.2"
+    kind: bundle
+    required_agents:
+      - "foundation:explorer"
+      - "foundation:zen-architect"
+# ---------------------------------------------------------------------------
+
 name: "outline-generation-from-document"
 description: "Generate structured outlines from existing documents with source identification, directionality detection, and classification"
-version: "1.6.1"
+version: "1.7.0"
 author: "Recipe Author Agent"
 tags: ["documentation", "outline", "analysis", "source-identification", "directionality", "authority-detection"]
 
 # =============================================================================
 # CHANGELOG
 # =============================================================================
+# v1.7.0 (2026-09-02):
+#   - PORTABILITY: declare a schema_version 2 dependency manifest
+#     (contract recipe-dependency-manifest.v1; block sits above `name:`)
+#     * The `agent: "foundation:explorer"` / `"foundation:zen-architect"` steps
+#       below previously resolved out of the CALLING session's agent map; a
+#       caller without them failed at run time with "Agent
+#       'foundation:zen-architect' not found in configuration"
+#     * They now resolve from this recipe's own declared closure
+#     * The "Requirements: foundation bundle" line in the header above is now
+#       enforced by the manifest rather than left to the caller
+#   - No behavior change under the legacy engine, which ignores both new
+#     top-level keys. Recipe logic, steps and prompts untouched.
+#
 # v1.6.1 (2026-01-15):
 #   - BUGFIX: JSON parsing failures when LLM outputs unescaped quotes in prompt strings
 #     * Root cause: Code examples inside prompts had quotes like "~/repos/foo" that

--- a/recipes/repo-activity-analysis.yaml
+++ b/recipes/repo-activity-analysis.yaml
@@ -1,6 +1,23 @@
+# --- Dependency manifest (contract: recipe-dependency-manifest.v1) ----------
+# schema_version 2 makes this recipe portable: every `agent:` reference below
+# resolves ONLY from the declared closure here, never from the calling
+# session's agent map. A caller that lacks these agents can still run it.
+# Pinned to the released tag `v2.1.2`. Foundation fetches a ref with
+# `git clone --branch`, which accepts a branch or a tag but NOT a commit SHA,
+# so a tag is the most immutable pin a `source:` can currently express.
+schema_version: 2
+
+dependencies:
+  - source: "git+https://github.com/microsoft/amplifier-foundation@v2.1.2"
+    kind: bundle
+    required_agents:
+      - "foundation:explorer"
+      - "foundation:zen-architect"
+# ---------------------------------------------------------------------------
+
 name: "repo-activity-analysis"
 description: "Analyze a GitHub repository for commits and PRs in a date range. Defaults to current repo since yesterday."
-version: "3.1.0"
+version: "3.2.0"
 author: "Amplifier Recipes"
 tags: ["github", "analysis", "commits", "prs", "git", "activity"]
 
@@ -8,6 +25,16 @@ tags: ["github", "analysis", "commits", "prs", "git", "activity"]
 #
 # Analyzes a single GitHub repository for commits and PRs in a date range.
 # Defaults to the current working directory's repo and "since yesterday".
+#
+# v3.2.0: Portability - declare a schema_version 2 dependency manifest
+#         (contract recipe-dependency-manifest.v1, block at top of file)
+#         - The `agent: "foundation:explorer"` / `"foundation:zen-architect"`
+#           steps below previously resolved out of the CALLING session's agent
+#           map; a caller without them failed at run time with
+#           "Agent 'foundation:explorer' not found in configuration"
+#         - They now resolve from this recipe's own declared closure
+#         - No behavior change under the legacy engine, which ignores both new
+#           top-level keys. Recipe logic, steps and prompts untouched.
 #
 # v3.1.0: Model selection optimization for cost/performance
 #         - haiku for simple tasks: date parsing, commit chunk categorization

--- a/recipes/repo-audit.yaml
+++ b/recipes/repo-audit.yaml
@@ -1,6 +1,31 @@
+# --- Dependency manifest (contract: recipe-dependency-manifest.v1) ----------
+# schema_version 2 makes this recipe portable: every `agent:` reference below
+# resolves ONLY from the declared closure here, never from the calling
+# session's agent map. A caller that lacks these agents can still run it.
+# Pinned to the released tag `v2.1.2`. Foundation fetches a ref with
+# `git clone --branch`, which accepts a branch or a tag but NOT a commit SHA,
+# so a tag is the most immutable pin a `source:` can currently express.
+#
+# v1.10.0 -- this block is the only change. Previously the two
+# `agent: "foundation:*"` steps below resolved out of the CALLING session's
+# agent map; a caller without those agents failed at run time with
+# "Agent 'foundation:zen-architect' not found in configuration". They now
+# resolve from this recipe's own declared closure. No behavior change under
+# the legacy engine, which ignores both new top-level keys. Recipe logic,
+# steps and prompts untouched.
+schema_version: 2
+
+dependencies:
+  - source: "git+https://github.com/microsoft/amplifier-foundation@v2.1.2"
+    kind: bundle
+    required_agents:
+      - "foundation:modular-builder"
+      - "foundation:zen-architect"
+# ---------------------------------------------------------------------------
+
 name: "repo-audit"
 description: "Audit a single Amplifier ecosystem repository for compliance with Microsoft standards and Amplifier guidelines."
-version: "1.9.0"
+version: "1.10.0"
 author: "Amplifier Team"
 tags: ["audit", "compliance", "github", "amplifier"]
 


### PR DESCRIPTION
## What changed

Migrates 6 of 7 recipes to `schema_version: 2` dependency manifests, with dependencies pinned to `foundation@v2.1.2`:

- `repo-audit`
- `amplifier-ecosystem-audit`
- `repo-activity-analysis`
- `ecosystem-activity-report`
- `outline-generation-from-doc`
- `document-generation`

`ecosystem-audit-batch` is **deliberately left legacy** — it references no agents, so there is no closure to declare.

## Why

Production failure in session `e9f4cdaa`: `repo-audit` died on

```
Agent 'foundation:zen-architect' not found in configuration
```

under a lean caller bundle. Every `agent:` reference previously resolved out of the *calling* session's agent map, so a recipe only worked when the caller's bundle happened to carry the right agents. A schema v2 dependency manifest closes that — agents resolve from each recipe's own declared closure, regardless of the session's bundle.

## How to verify

- Every migrated recipe **plan-verified** against the shipped parser/planner with **no caller agents** present.
- Every migrated recipe still **loads clean under the legacy engine** — error/warning counts identical to the `HEAD` baseline.

## Design note

`document-generation` declares **one** foundation dependency, not two, despite referencing both the `foundation:` and `design-intelligence:` namespaces. The design-intelligence agents are supplied via foundation's own includes; declaring a second dependency collides — this was tried and rejected with `AgentCollisionError`.

## Breaking changes

None. The unmigrated recipe is unchanged, and migrated recipes remain loadable by the legacy engine.

Generated with Amplifier

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
