### PR TITLE
fix(recipes): ecosystem-audit-batch must not report 'completed' when the whole batch failed to audit

### DIFF
--- a/recipes/amplifier-ecosystem-audit.yaml
+++ b/recipes/amplifier-ecosystem-audit.yaml
@@ -27,8 +27,8 @@ dependencies:
 # ---------------------------------------------------------------------------
 
 name: "amplifier-ecosystem-audit"
-description: "Audit all Amplifier ecosystem repositories (public and private) in the Microsoft GitHub organization for compliance. Uses a batched architecture (configurable batch_size, default 25) with public/private separation; scales past 100 repos and supports the audit_visibility filter. Aggregates per-repo Dependabot open-PR findings to the top-level report as always-reported warnings."
-version: "2.2.0"
+description: "Audit all Amplifier ecosystem repositories (public and private) in the Microsoft GitHub organization for compliance. Uses a batched architecture (configurable batch_size, default 25) with public/private separation; scales past 100 repos and supports the audit_visibility filter. Aggregates per-repo Dependabot open-PR findings to the top-level report as always-reported warnings, and surfaces per-batch audit coverage (batch_health) so a batch that audited nothing is never mistaken for a clean one."
+version: "2.3.0"
 author: "Amplifier Team"
 tags: ["audit", "compliance", "github", "amplifier", "ecosystem", "multi-repo"]
 
@@ -72,7 +72,45 @@ tags: ["audit", "compliance", "github", "amplifier", "ecosystem", "multi-repo"]
 # Requirements:
 #   - gh CLI installed and authenticated
 #   - repo-audit.yaml recipe (in same directory)
+#   - ecosystem-audit-batch.yaml >= v1.2.0 (writes the per-batch
+#     <batch_id>.health.json this recipe's collect-batch-health step reads)
 #   - Write access to repos if create_fix_prs is "true"
+#
+# =============================================================================
+# CHANGELOG
+# =============================================================================
+#
+# v2.3.0 (2026-09-05):
+#   - COVERAGE VISIBILITY: surface batch health end to end (work item
+#     recipes-kj5). `audit-batches` sets on_error: "continue" so one bad batch
+#     cannot sink the ecosystem run — but that also meant a run in which every
+#     batch audited NOTHING still produced a confident report, because the only
+#     evidence was a per-repo "status":"MISSING" marker buried in the JSONL.
+#     * NEW STEP `collect-batch-health` (deterministic bash, no LLM,
+#       on_error: "fail") is now the FIRST step of the reporting stage. It
+#       reads the <batch_id>.health.json files written by
+#       ecosystem-audit-batch.yaml v1.2.0, rolls them up into
+#       findings/batch-health-summary.json, and FAILS THE RUN when zero repos
+#       were audited across all batches — before the two report-generating LLM
+#       steps run, so the recipe never spends a model call describing an audit
+#       that did not happen.
+#     * A batch whose health file is absent (the batch died before its own
+#       check ran) is counted as `batches_unreported`, and one that is present
+#       but unparseable as `batches_unreadable` — neither is silently skipped.
+#     * `aggregate-results` now carries `batch_health` in its output (read back
+#       from batch-health-summary.json, not interpolated), so it lands in
+#       reports/aggregate-data.json too.
+#     * The report prompt gains a MANDATORY "Batch Health" executive-summary
+#       line and a "Batch Health" section, both required to state that repos
+#       which failed to audit are a COVERAGE GAP, not a clean bill of health.
+#     * `completion-summary` prints the same audited/failed/batches figures.
+#     * Report footer version string corrected (was still v2.1.0 at v2.2.0).
+#   - No change to discovery, batching, or the audits stage.
+#
+# v2.2.0:
+#   - PORTABILITY: declare a schema_version 2 dependency manifest
+#     (contract recipe-dependency-manifest.v1; block at top of file). See the
+#     note above `schema_version:` for the full rationale.
 
 recursion:
   max_depth: 5
@@ -596,6 +634,124 @@ stages:
   # ==========================================================================
   - name: "reporting"
     steps:
+      # ------------------------------------------------------------------
+      # Batch health rollup (deterministic; no LLM) — runs FIRST.
+      #
+      # `audit-batches` sets on_error: "continue" on purpose: one bad batch
+      # must not sink the ecosystem run. ecosystem-audit-batch.yaml v1.2.0
+      # now writes <batch_id>.health.json per batch, so this step can tell
+      # a healthy batch from a partial one from one that audited NOTHING —
+      # without parsing per-repo "MISSING" markers out of the JSONL
+      # (recipes-kj5).
+      #
+      # It runs before collect-individual-reports so a run in which every
+      # batch produced nothing fails HERE, loudly, rather than spending two
+      # LLM calls generating a confident report about zero audits.
+      # ------------------------------------------------------------------
+      - id: "collect-batch-health"
+        type: "bash"
+        parse_json: true
+        command: |
+          set -euo pipefail
+          FINDINGS_DIR="{{working_dir}}/findings"
+          EXPECTED_BATCHES={{split.total_batches}}
+          SUMMARY="$FINDINGS_DIR/batch-health-summary.json"
+
+          mkdir -p "$FINDINGS_DIR"
+
+          HEALTH_TMP=$(mktemp)
+          trap 'rm -f "$HEALTH_TMP"' EXIT
+
+          shopt -s nullglob
+          HEALTH_FILES=("$FINDINGS_DIR"/*.health.json)
+          for hf in "${HEALTH_FILES[@]}"; do
+            # A malformed health file is reported as such, never skipped
+            # silently — a batch we cannot read is not a batch that passed.
+            if jq -e . "$hf" > /dev/null 2>&1; then
+              jq -c '.' "$hf" >> "$HEALTH_TMP"
+            else
+              jq -nc --arg f "$hf" \
+                '{batch_id: ($f | split("/") | last | sub("\\.health\\.json$"; "")),
+                  visibility: "unknown", health: "unreadable",
+                  repos_total: 0, repos_audited: 0, repos_failed: 0,
+                  failed_repos: [], failures: []}' >> "$HEALTH_TMP"
+            fi
+          done
+
+          if [ -s "$HEALTH_TMP" ]; then
+            BATCHES=$(jq -s -c '.' "$HEALTH_TMP")
+          else
+            BATCHES="[]"
+          fi
+
+          SUMMARY_JSON=$(jq -n \
+            --argjson batches "$BATCHES" \
+            --argjson expected "$EXPECTED_BATCHES" \
+            '{
+              batches_expected: $expected,
+              batches_reported: ($batches | length),
+              batches_unreported: (($expected - ($batches | length)) | if . < 0 then 0 else . end),
+              batches_ok:        ([$batches[] | select(.health == "ok")]        | length),
+              batches_partial:   ([$batches[] | select(.health == "partial")]   | length),
+              batches_empty:     ([$batches[] | select(.health == "empty")]     | length),
+              batches_unreadable:([$batches[] | select(.health == "unreadable")]| length),
+              repos_audited: ([$batches[] | .repos_audited // 0] | add // 0),
+              repos_failed:  ([$batches[] | .repos_failed  // 0] | add // 0),
+              failed_repos:  ([$batches[] | .failed_repos[]? ] | unique),
+              failing_batches: [$batches[] | select(.health == "empty" or .health == "partial" or .health == "unreadable")
+                                | {batch_id, visibility, health, repos_audited, repos_failed, failed_repos}],
+              # Compact on purpose: this rollup is interpolated into the report
+              # prompt. The verbose per-repo `failures` reasons stay in each
+              # batch is own <batch_id>.health.json rather than being copied here.
+              per_batch: [$batches[] | {batch_id, visibility, health, repos_total, repos_audited, repos_failed, failed_repos}]
+            }
+            | .health = (
+                if .repos_audited == 0 then "empty"
+                elif (.repos_failed > 0 or .batches_unreported > 0 or .batches_empty > 0 or .batches_unreadable > 0) then "partial"
+                else "ok" end
+              )')
+
+          printf '%s\n' "$SUMMARY_JSON" > "$SUMMARY"
+          printf '%s\n' "$SUMMARY_JSON"
+
+          AUDITED=$(jq -r '.repos_audited' <<< "$SUMMARY_JSON")
+          OVERALL=$(jq -r '.health' <<< "$SUMMARY_JSON")
+
+          if [ "$AUDITED" -eq 0 ]; then
+            {
+              echo "========================================================"
+              echo "ECOSYSTEM AUDIT PRODUCED NOTHING"
+              echo "========================================================"
+              jq -r '"Batches expected   : \(.batches_expected)",
+                     "Batches reporting  : \(.batches_reported)",
+                     "  ok / partial     : \(.batches_ok) / \(.batches_partial)",
+                     "  empty            : \(.batches_empty)",
+                     "  unreadable       : \(.batches_unreadable)",
+                     "  never reported   : \(.batches_unreported)",
+                     "Repos audited      : \(.repos_audited)",
+                     "Repos failed       : \(.repos_failed)"' <<< "$SUMMARY_JSON"
+              echo ""
+              echo "Not one repository in any batch produced an audit report."
+              echo "Per-batch detail:"
+              jq -r '.failing_batches[]? | "  - \(.batch_id) (\(.visibility)): \(.health), audited \(.repos_audited), failed \(.repos_failed)"' <<< "$SUMMARY_JSON"
+              echo ""
+              echo "Batch health summary written to: $SUMMARY"
+              echo "Refusing to generate an ecosystem report over zero audits."
+              echo "========================================================"
+            } >&2
+            exit 1
+          fi
+
+          if [ "$OVERALL" != "ok" ]; then
+            {
+              echo "WARNING: ecosystem audit is PARTIAL — see $SUMMARY"
+              jq -r '.failing_batches[]? | "  - \(.batch_id) (\(.visibility)): \(.health), audited \(.repos_audited), failed \(.repos_failed)"' <<< "$SUMMARY_JSON"
+            } >&2
+          fi
+        output: "batch_health"
+        timeout: 120
+        on_error: "fail"
+
       - id: "collect-individual-reports"
         type: "bash"
         command: |
@@ -736,7 +892,20 @@ stages:
             DEP_PER_REPO="[]"
           fi
 
+          # Batch health, computed by collect-batch-health and read back from
+          # its own file rather than interpolated: the aggregate must carry
+          # batch health so the report and the saved aggregate-data.json both
+          # show partial failure without anyone re-deriving it from MISSING
+          # markers (recipes-kj5).
+          BATCH_HEALTH_FILE="$FINDINGS_DIR/batch-health-summary.json"
+          if [ -s "$BATCH_HEALTH_FILE" ] && jq -e . "$BATCH_HEALTH_FILE" > /dev/null 2>&1; then
+            BATCH_HEALTH=$(jq -c '.' "$BATCH_HEALTH_FILE")
+          else
+            BATCH_HEALTH='{"health":"unknown","reason":"batch-health-summary.json missing or unreadable"}'
+          fi
+
           jq -n \
+            --argjson batch_health "$BATCH_HEALTH" \
             --argjson total "$TOTAL" \
             --argjson pass "$PASS" \
             --argjson attention "$ATTENTION" \
@@ -754,6 +923,7 @@ stages:
             --argjson dep_per_repo "$DEP_PER_REPO" \
             '{
               total_repos: $total,
+              batch_health: $batch_health,
               by_status: {
                 pass: $pass,
                 needs_attention: $attention,
@@ -810,12 +980,49 @@ stages:
           | NEEDS ATTENTION | N | X% |
           | CRITICAL | N | X% |
           
+          **Batch Health**: [From aggregate_data.batch_health. If health is "ok",
+          write "all N batches audited cleanly — OK". If health is "partial", write
+          "PARTIAL — A of B batches reported, X repos audited, Y repos failed to
+          audit (list failed_repos)". If health is "unknown", say so plainly rather
+          than implying success. This line is mandatory and must always be present.]
+          
           **Dependabot**: [From aggregate_data.dependabot. If total_prs > 0, write
           "N open PRs across M repos (S security-flagged) — WARNING". If total_prs is 0,
           write "none open — OK". This line is mandatory and must always be present.]
           
           **Key Findings**:
           - [Top 3-5 most important findings across ecosystem]
+          
+          ## Batch Health
+          
+          ALWAYS render this section. Source every number from the
+          `batch_health` object in aggregate_data — never from per-repo MISSING
+          markers, and never infer it from the repo counts elsewhere in this
+          report. A repo that was never audited is NOT the same as a repo that
+          was audited and found wanting; this section is the only place that
+          distinction is stated.
+          
+          - **Overall**: [batch_health.health — ok / partial / empty / unknown]
+          - **Batches**: [batch_health.batches_reported] of
+            [batch_health.batches_expected] reported
+            ([batch_health.batches_ok] ok, [batch_health.batches_partial] partial,
+            [batch_health.batches_empty] empty,
+            [batch_health.batches_unreported] never reported)
+          - **Repos audited**: [batch_health.repos_audited]
+          - **Repos that failed to audit**: [batch_health.repos_failed]
+          
+          If `batch_health.repos_failed` is 0 and `batch_health.health` is "ok",
+          add the line "All batches audited cleanly." and nothing else.
+          
+          Otherwise list every failing batch from `batch_health.failing_batches`:
+          
+          | Batch | Visibility | Health | Audited | Failed | Failed repos |
+          |-------|------------|--------|---------|--------|--------------|
+          | batch-pub-01 | public | partial | N | N | repo-a, repo-b |
+          
+          State explicitly that repos listed here were NOT audited, so their
+          absence from the PASS / NEEDS ATTENTION / CRITICAL counts above is a
+          gap in coverage, not a clean bill of health.
           
           ## Compliance Overview
           
@@ -900,7 +1107,7 @@ stages:
           3. [Long-term governance recommendations]
           
           ---
-          *Generated by Amplifier ecosystem-audit recipe v2.1.0*
+          *Generated by Amplifier ecosystem-audit recipe v2.3.0*
         output: "ecosystem_report_content"
         timeout: 600
         on_error: "fail"
@@ -956,6 +1163,7 @@ stages:
           # Show summary stats
           echo "Quick Stats:"
           cat "{{working_dir}}/reports/aggregate-data.json" 2>/dev/null | jq -r '
+            "  Batch health: \(.batch_health.health // "unknown") — \(.batch_health.repos_audited // 0) repos audited, \(.batch_health.repos_failed // 0) failed to audit across \(.batch_health.batches_reported // 0)/\(.batch_health.batches_expected // 0) batches",
             "  Total repos: \(.total_repos)",
             "    Public: \(.by_visibility.public // 0)",
             "    Private: \(.by_visibility.private // 0)",

--- a/recipes/ecosystem-audit-batch.yaml
+++ b/recipes/ecosystem-audit-batch.yaml
@@ -1,6 +1,23 @@
+# --- Dependency manifest (contract: recipe-dependency-manifest.v1) ----------
+# schema_version 2 makes this recipe portable: an `agent:` reference resolves
+# ONLY from the declared closure here, never from the calling session's agent
+# map. This recipe has NO `agent:` steps of its own -- every step is `bash` or
+# `recipe` -- so its closure is genuinely EMPTY, and `dependencies: []` is the
+# way manifest.v1 says "declare none". Declaring it explicitly is the point:
+# it states that this recipe needs nothing from its caller, rather than
+# leaving that to be inferred from the absence of a block.
+#
+# NOTE: the sub-recipe this recipe invokes (`repo-audit.yaml`) carries its own
+# manifest -- a sub-recipe's closure is its own, not inherited from here, and
+# not narrowed by this recipe's empty one.
+schema_version: 2
+
+dependencies: []
+# ---------------------------------------------------------------------------
+
 name: "ecosystem-audit-batch"
-description: "Sub-recipe for amplifier-ecosystem-audit.yaml. Audits the repos in one batch file, then flushes per-repo findings as JSONL. Visibility-agnostic — reads visibility from the batch file."
-version: "1.1.0"
+description: "Sub-recipe for amplifier-ecosystem-audit.yaml. Audits the repos in one batch file, flushes per-repo findings as JSONL, then checks batch health and fails loud when the whole batch produced no audit at all. Visibility-agnostic — reads visibility from the batch file."
+version: "1.2.0"
 author: "Amplifier Team"
 tags: ["audit", "compliance", "github", "amplifier", "ecosystem", "batch"]
 
@@ -14,14 +31,57 @@ tags: ["audit", "compliance", "github", "amplifier", "ecosystem", "batch"]
 #   1. Load the batch file and expose repos + visibility metadata
 #   2. Foreach repo in batch (parallel: 2), invoke repo-audit.yaml
 #   3. Flush a JSONL findings file with one line per repo
+#   4. Check batch health: fail loud if NOTHING in the batch was audited,
+#      otherwise record an explicit audited/failed summary for the caller
 #
 # The JSONL findings file is the durable per-batch summary. Filename
 # encodes visibility (batch-pub-NN.jsonl or batch-priv-NN.jsonl); each
 # line embeds the visibility field for redundant clarity.
 #
+# Alongside it, step 4 writes <batch_id>.health.json in the same findings
+# directory. That file — not the per-repo "MISSING" markers — is what the
+# parent recipe reads to tell a healthy batch from a partial one from a batch
+# that audited nothing at all.
+#
 # Requirements:
 #   - repo-audit.yaml in the same directory
 #   - batch_file produced by split-into-batches step in parent recipe
+#
+# =============================================================================
+# CHANGELOG
+# =============================================================================
+#
+# v1.2.0 (2026-09-05):
+#   - BUGFIX: the recipe reported {'status': 'completed'} when 100% of the
+#     batch's repos failed to audit (work item recipes-kj5). `on_error:
+#     "continue"` on the audit-repos-in-batch foreach is deliberate and stays
+#     — one bad repo must not sink a 25-repo batch — but it also swallowed the
+#     case where EVERY repo failed. flush-batch-findings then wrote a
+#     success-shaped JSONL file whose lines all said "status":"MISSING", and
+#     the caller saw completed + a findings file. Only the per-repo MISSING
+#     marker distinguished "audited and genuinely absent" from "never audited".
+#     * NEW STEP `check-batch-health` (deterministic bash, no LLM, on_error:
+#       "fail") runs after flush-batch-findings. It reads what that step
+#       already computed and:
+#         - exits non-zero when ZERO repos produced an audit-report.md,
+#           naming the batch id and the per-repo failure reason for each;
+#         - passes when >= 1 repo audited, but always writes an explicit
+#           batch_health summary (health/repos_audited/repos_failed/
+#           failed_repos/failures) to <findings>/<batch_id>.health.json.
+#     * flush-batch-findings runs with on_error: "continue", so its own
+#       failure must not read as "nothing to check": when the JSONL is absent
+#       or empty the check falls back to the batch file itself and reports
+#       every named repo as failed rather than reporting an empty batch.
+#   - PORTABILITY: declare a schema_version 2 dependency manifest
+#     (contract recipe-dependency-manifest.v1; block sits above `name:`).
+#     This recipe has no `agent:` steps, so the closure is `dependencies: []`.
+#     No behavior change under the legacy engine, which ignores both new
+#     top-level keys.
+#
+# v1.1.0:
+#   - flush-batch-findings picks up repo-audit's dependabot.json and embeds
+#     dependabot_count / dependabot_security_count / dependabot_severity in
+#     each per-repo JSONL line.
 
 recursion:
   max_depth: 3
@@ -151,3 +211,187 @@ stages:
         output: "flush_result"
         timeout: 120
         on_error: "continue"
+
+      # ------------------------------------------------------------------
+      # Batch health check (deterministic; no LLM)
+      #
+      # `audit-repos-in-batch` sets on_error: "continue" on purpose: one bad
+      # repo must not sink a 25-repo batch. But that also swallowed the case
+      # where EVERY repo failed — the recipe still returned 'completed' and
+      # flush-batch-findings still wrote a success-shaped findings file whose
+      # lines all said "status":"MISSING" (recipes-kj5).
+      #
+      # This step reads what flush-batch-findings already computed and draws
+      # the line the foreach cannot:
+      #   audited >= 1  -> pass, and record audited/failed + failed repo names
+      #                    in <batch_id>.health.json so the caller sees partial
+      #                    failure WITHOUT parsing per-repo MISSING markers
+      #   audited == 0  -> fail loud, naming the batch and why each repo failed
+      # ------------------------------------------------------------------
+      - id: "check-batch-health"
+        type: "bash"
+        parse_json: true
+        command: |
+          set -euo pipefail
+          BATCH_ID="{{batch.batch_id}}"
+          VISIBILITY="{{batch.visibility}}"
+          BATCH_FILE="{{batch_file}}"
+          WORKING_DIR="{{working_dir}}"
+          REPORTS_DIR="$WORKING_DIR/repos"
+          FINDINGS_DIR="$WORKING_DIR/findings"
+          FINDINGS="$FINDINGS_DIR/${BATCH_ID}.jsonl"
+          HEALTH="$FINDINGS_DIR/${BATCH_ID}.health.json"
+
+          mkdir -p "$FINDINGS_DIR"
+
+          FAILED_TMP=$(mktemp)
+          FAILURES_TMP=$(mktemp)
+          trap 'rm -f "$FAILED_TMP" "$FAILURES_TMP"' EXIT
+
+          # Why a named repo has no audit report, from on-disk evidence only.
+          # Deliberately does not guess a cause it cannot see.
+          reason_for() {
+            local owner="$1" name="$2"
+            local report="$REPORTS_DIR/$name/audit-report.md"
+            if [ ! -d "$REPORTS_DIR/$name" ]; then
+              echo "no audit report at $report — the per-repo output directory was never created, so repo-audit.yaml for $owner/$name did not get past its first step"
+            else
+              echo "no audit report at $report — the per-repo output directory exists, so repo-audit.yaml for $owner/$name started and failed before writing its report"
+            fi
+          }
+
+          record_failure() {
+            local owner="$1" name="$2" reason
+            reason="$(reason_for "$owner" "$name")"
+            echo "$name" >> "$FAILED_TMP"
+            jq -nc --arg repo "$name" --arg owner "$owner" --arg reason "$reason" \
+              '{repo: $repo, owner: $owner, reason: $reason}' >> "$FAILURES_TMP"
+          }
+
+          TOTAL=0
+          AUDITED=0
+          FAILED=0
+          FINDINGS_FLUSHED=true
+
+          if [ ! -s "$FINDINGS" ]; then
+            # flush-batch-findings runs with on_error: "continue", so its own
+            # failure must never read as "nothing to check". Fall back to the
+            # batch file: every repo the batch NAMED is accounted for.
+            FINDINGS_FLUSHED=false
+            while IFS= read -r repo_json; do
+              [ -z "$repo_json" ] && continue
+              REPO_NAME=$(echo "$repo_json" | jq -r '.name')
+              REPO_OWNER=$(echo "$repo_json" | jq -r '.owner')
+              TOTAL=$((TOTAL + 1))
+              if [ -f "$REPORTS_DIR/$REPO_NAME/audit-report.md" ]; then
+                AUDITED=$((AUDITED + 1))
+              else
+                FAILED=$((FAILED + 1))
+                record_failure "$REPO_OWNER" "$REPO_NAME"
+              fi
+            done < <(jq -c '.repos[]' "$BATCH_FILE")
+          else
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              REPO_NAME=$(echo "$line" | jq -r '.repo')
+              REPO_OWNER=$(echo "$line" | jq -r '.owner')
+              STATUS=$(echo "$line" | jq -r '.status')
+              TOTAL=$((TOTAL + 1))
+              if [ "$STATUS" = "MISSING" ]; then
+                FAILED=$((FAILED + 1))
+                record_failure "$REPO_OWNER" "$REPO_NAME"
+              else
+                AUDITED=$((AUDITED + 1))
+              fi
+            done < "$FINDINGS"
+          fi
+
+          if [ -s "$FAILED_TMP" ]; then
+            FAILED_REPOS=$(jq -R -s -c 'split("\n") | map(select(length > 0))' "$FAILED_TMP")
+          else
+            FAILED_REPOS="[]"
+          fi
+          if [ -s "$FAILURES_TMP" ]; then
+            FAILURES=$(jq -s -c '.' "$FAILURES_TMP")
+          else
+            FAILURES="[]"
+          fi
+
+          # empty   — nothing in this batch was audited (or the batch named no
+          #           repos at all); the batch produced no usable finding
+          # partial — at least one repo audited, at least one failed
+          # ok      — every repo in the batch produced an audit report
+          if [ "$AUDITED" -eq 0 ]; then
+            HEALTH_STATUS="empty"
+          elif [ "$FAILED" -gt 0 ]; then
+            HEALTH_STATUS="partial"
+          else
+            HEALTH_STATUS="ok"
+          fi
+
+          jq -n \
+            --arg batch_id "$BATCH_ID" \
+            --arg visibility "$VISIBILITY" \
+            --arg health "$HEALTH_STATUS" \
+            --arg findings_file "$FINDINGS" \
+            --argjson findings_flushed "$FINDINGS_FLUSHED" \
+            --argjson repos_total "$TOTAL" \
+            --argjson repos_audited "$AUDITED" \
+            --argjson repos_failed "$FAILED" \
+            --argjson failed_repos "$FAILED_REPOS" \
+            --argjson failures "$FAILURES" \
+            --arg checked_at "$(date -Iseconds)" \
+            '{
+              batch_id: $batch_id,
+              visibility: $visibility,
+              health: $health,
+              repos_total: $repos_total,
+              repos_audited: $repos_audited,
+              repos_failed: $repos_failed,
+              failed_repos: $failed_repos,
+              failures: $failures,
+              findings_file: $findings_file,
+              findings_flushed: $findings_flushed,
+              checked_at: $checked_at
+            }' > "$HEALTH"
+
+          cat "$HEALTH"
+
+          if [ "$AUDITED" -eq 0 ]; then
+            {
+              echo "========================================================"
+              echo "BATCH AUDIT PRODUCED NOTHING: $BATCH_ID ($VISIBILITY)"
+              echo "========================================================"
+              echo "Repos named in batch : $TOTAL"
+              echo "Repos audited        : 0"
+              echo "Repos failed         : $FAILED"
+              if [ "$FINDINGS_FLUSHED" = "false" ]; then
+                echo "Findings file        : MISSING or empty ($FINDINGS)"
+                echo "  flush-batch-findings did not produce a findings file for"
+                echo "  this batch; repo state was read from $BATCH_FILE instead."
+              else
+                echo "Findings file        : $FINDINGS (every line status=MISSING)"
+              fi
+              echo ""
+              if [ "$TOTAL" -eq 0 ]; then
+                echo "This batch named NO repositories at all. split-into-batches"
+                echo "in the parent recipe should never emit an empty batch, so"
+                echo "$BATCH_FILE is itself suspect."
+              else
+                echo "Per-repo failure reasons:"
+                jq -r '.[] | "  - \(.owner)/\(.repo): \(.reason)"' <<< "$FAILURES"
+              fi
+              echo ""
+              echo "Batch health written to: $HEALTH"
+              echo "Refusing to report this batch as completed."
+              echo "========================================================"
+            } >&2
+            exit 1
+          fi
+
+          if [ "$FAILED" -gt 0 ]; then
+            echo "WARNING: batch $BATCH_ID is PARTIAL — audited $AUDITED, failed $FAILED ($(jq -r 'join(", ")' <<< "$FAILED_REPOS"))" >&2
+          fi
+        output: "batch_health"
+        timeout: 120
+        on_error: "fail"


### PR DESCRIPTION
## Defect

`recipes/ecosystem-audit-batch.yaml` returned `{'status': 'completed'}` when **100% of the batch's repos failed to audit**, and `flush-batch-findings` wrote a success-shaped findings file alongside it. The only thing distinguishing "audited and genuinely absent" from "never audited at all" was a per-repo `"status":"MISSING"` marker buried in the JSONL — which the caller (`amplifier-ecosystem-audit.yaml`) never read.

`on_error: "continue"` on the foreach is **deliberate and correct** — one bad repo must not sink a 25-repo batch — so the fix is not to remove it. It is to draw the line the foreach cannot.

Work item: **recipes-kj5**.

## Root cause

- `recipes/ecosystem-audit-batch.yaml:82` (pre-change) — `on_error: "continue"` on `audit-repos-in-batch` swallows every per-repo failure, including "all of them".
- `recipes/ecosystem-audit-batch.yaml:84-153` (pre-change) — `flush-batch-findings` was the **last** step, and it writes a findings line for every repo whether or not that repo produced an `audit-report.md`. It has no verdict; nothing after it did either.
- `recipes/amplifier-ecosystem-audit.yaml:626` (pre-change) — `aggregate-results` counts `MISSING` into `needs_attention` (its `*)` case), so a never-audited repo was reported as an audited-but-imperfect one.

## Change

**`recipes/ecosystem-audit-batch.yaml` 1.1.0 → 1.2.0**

- **NEW STEP `check-batch-health`** (deterministic bash, no LLM, `on_error: "fail"`) after `flush-batch-findings`. Reads what flush already computed and:
  - **fails loud** when zero repos produced an `audit-report.md`, naming the batch id, the findings file, and a per-repo failure reason derived from on-disk evidence only (per-repo output dir never created → the sub-recipe never got past its first step; dir present but no report → it started and failed before writing);
  - **passes** when ≥1 repo audited, and *always* writes `<findings>/<batch_id>.health.json` carrying `health` (`ok`/`partial`/`empty`), `repos_total`, `repos_audited`, `repos_failed`, `failed_repos`, `failures[]`.
- `flush-batch-findings` runs with `on_error: "continue"`, so its own failure must not read as "nothing to check": an absent/empty JSONL falls back to the batch file and accounts for every repo the batch **named** (`findings_flushed: false`).
- A batch naming zero repos is also a loud failure — `split-into-batches` never emits one, so such a batch file is itself suspect.
- **Migrated to `schema_version: 2`** with `dependencies: []`. This recipe has no `agent:` steps, so its closure is genuinely empty; declaring it states that it needs nothing from its caller rather than leaving that inferred. `repo-audit.yaml`'s own closure is unaffected.

**`recipes/amplifier-ecosystem-audit.yaml` 2.2.0 → 2.3.0**

- **NEW STEP `collect-batch-health`** — now the **first** step of the reporting stage, `on_error: "fail"`. Rolls the per-batch health files into `findings/batch-health-summary.json` and **fails the run when zero repos were audited across all batches** — *before* the two report-generating LLM steps, so the recipe never spends a model call describing an audit that did not happen. A batch that died before its own check ran counts as `batches_unreported`; a present-but-unparseable health file as `batches_unreadable`. Neither is silently skipped.
- `aggregate-results` now carries `batch_health` (read back from the summary file, not interpolated), so it lands in `reports/aggregate-data.json` too.
- Report prompt gains a **mandatory** `**Batch Health**` executive-summary line and a `## Batch Health` section, both required to state that repos which failed to audit are a **coverage gap, not a clean bill of health**.
- `completion-summary` prints the same audited/failed/batches figures. Report footer version string corrected (was still `v2.1.0` at v2.2.0).

Preserved as required: `on_error: "continue"` on both foreaches, `schema_version: 2` + `dependencies` on the caller, all existing step ids.

## Gates

**schema-v2 validate** — `PYTHONPATH=.../amplifier-bundle-recipes/src python3 -m amplifier_recipe_runner validate <recipe>`

| recipe | status |
|---|---|
| `amplifier-ecosystem-audit.yaml` | `status: ok`, `schema_version: 2` |
| `ecosystem-audit-batch.yaml` | `status: ok`, `schema_version: 2` (was `status: invalid` / `legacy: true` on base) |
| other 5 recipes | `status: ok` (untouched) |

**Legacy-engine load parity** — `Recipe.from_yaml` + `validate_recipe`, `PYTHONPATH=.../modules/tool-recipes`, base (`HEAD`) vs branch:

| recipe | base | branch |
|---|---|---|
| `amplifier-ecosystem-audit.yaml` | v2.2.0, 14 steps, `is_valid=True`, 0 errors | v2.3.0, 15 steps, `is_valid=True`, 0 errors |
| `ecosystem-audit-batch.yaml` | v1.1.0, 3 steps, `is_valid=True`, 0 errors | v1.2.0, 4 steps, `is_valid=True`, 0 errors |
| other 5 recipes | unchanged | unchanged (incl. pre-existing `ecosystem-activity-report.yaml` 11 errors, untouched) |

`is_valid` is unchanged for every file; step counts move by exactly the two added steps.

## Live proof

All runs `amplifier tool invoke -b anchors-amp-dev -o json recipes operation=execute ...` — the shipped engine from the bundle cache, reading the YAML from this branch. Logs under `dtu-artifacts/sweep/fix-kj5/`.

**The parent `amplifier-ecosystem-audit.yaml` pauses at an approval gate before its audits stage, so it cannot be driven to the reporting stage non-interactively. Running the BATCH recipe directly is the proof for the batch-level fix; the caller-level step is proved separately by feeding it the real health artifacts those runs produced** (see (c)).

### (a) NEGATIVE — a batch whose only repo cannot be audited

Fixture: batch names `microsoft/amplifier-does-not-exist-kj5`; `<working_dir>/repos` is a **regular file**, so `repo-audit.yaml`'s first step (`mkdir -p <wd>/repos/<name>`, `set -euo pipefail`, `on_error: "fail"`) fails and the sub-recipe never produces a report. `dry_run: "true"`, `create_fix_pr: "false"`.

> **Why not a bare non-existent repo name?** Measured: `repo-audit.yaml` is *resilient* to one. `fetch-repo-info` swallows the failure (`|| echo '{"error": ...}'`, exit 0), `validate-repo` emits `{"valid": false}` — and **nothing gates on it**. The run proceeds to `generate-report` and writes an `audit-report.md` anyway, so the batch would report 1 audited. The fixture above makes the audit genuinely fail, which is the condition under test. (Worth a separate item: `repo-audit.yaml` ignores its own `repo_validation.valid`.)

**Baseline, `main`'s v1.1.0, same fixture** (`NEG-baseline.log`) — the defect:
```
Step 'audit-repos-in-batch' iteration 0 failed: ... Step 'setup': command failed with exit code 1
{'status': 'completed', 'recipe': 'ecosystem-audit-batch', ... 'version': '1.1.0' ...
 'last_step': {'id': 'flush-batch-findings'},
 'final_output': 'Flushed 1 findings for batch-neg-01 (public) to .../findings/batch-neg-01.jsonl'}
```
```json
{"repo":"amplifier-does-not-exist-kj5","owner":"microsoft","status":"MISSING", ...}
```

**Branch, v1.2.0, identical fixture** (`NEG-fixed.log`) — fails at the new step:
```
v2 recipe .../ecosystem-audit-batch.yaml failed on the legacy engine:
Step 'check-batch-health': command failed with exit code 1
stderr: ========================================================
BATCH AUDIT PRODUCED NOTHING: batch-neg-01 (public)
========================================================
Repos named in batch : 1
Repos audited        : 0
Repos failed         : 1
Findings file        : .../findings/batch-neg-01.jsonl (every line status=MISSING)

Per-repo failure reasons:
  - microsoft/amplifier-does-not-exist-kj5: no audit report at .../repos/amplifier-does-not-exist-kj5/audit-report.md — the per-repo output directory was never created, so repo-audit.yaml for microsoft/amplifier-does-not-exist-kj5 did not get past its first step

Batch health written to: .../findings/batch-neg-01.health.json
Refusing to report this batch as completed.
```
Result: `"Error: Recipe execution failed: Step 'check-batch-health'..."` — **not `completed`**.

### (b) POSITIVE — one real public repo

`microsoft/amplifier-bundle-notify`, `dry_run: "true"`, `create_fix_pr: "false"` (`POS-fixed.log`). Real agent steps ran (`foundation:modular-builder` → `NO_FIX_NEEDED`, `foundation:zen-architect` → report):
```
'status': 'completed'
'execution_mode': 'v2-closed-world-legacy-engine'
'version': '1.2.0'
'batch_health': {'batch_id': 'batch-pub-01', 'visibility': 'public', 'health': 'ok',
                 'repos_total': 1, 'repos_audited': 1, 'repos_failed': 0,
                 'failed_repos': [], 'failures': [], 'findings_flushed': True}
```
`findings/batch-pub-01.jsonl`: `{"repo":"amplifier-bundle-notify", ..., "status":"PASS", ...}`

### (c) CALLER propagation — `collect-batch-health` + `aggregate-results` on the REAL artifacts

The two `<batch_id>.health.json` files produced by (a) and (b) above, fed to the caller's new step (`CALLER-proof.log`):

| case | health files | `split.total_batches` | exit | rollup |
|---|---|---|---|---|
| A | only the failing batch | 2 | **1 (fails loud)** | `health: empty`, audited 0, failed 1, `batches_empty: 1`, `batches_unreported: 1` |
| B | failing + successful | 2 | 0 | `health: partial`, audited 1, failed 1, `batches_ok: 1`, `batches_empty: 1` |
| C | only the successful batch | 1 | 0 | `health: ok`, audited 1, failed 0 |

And `aggregate-results` over case B carries it through:
```json
{ "total_repos": 2,
  "batch_health": { "health": "partial", "repos_audited": 1, "repos_failed": 1,
                    "failed_repos": ["amplifier-does-not-exist-kj5"],
                    "failing_batches": [{"batch_id":"batch-neg-01","health":"empty", ...}] } }
```
The caller sees partial failure from `batch_health` alone — no per-repo `MISSING` marker parsed.

### Unit coverage of the two new steps

Both steps' bash was exercised standalone against fixtures before the live runs: batch step — all-MISSING (exit 1), partial (exit 0), all-ok (exit 0), missing-findings-with-a-report-on-disk (exit 0, `findings_flushed: false`), missing-findings-no-reports (exit 1), zero-repo batch (exit 1). Caller step — all-empty (exit 1), mixed (partial), no health files at all (exit 1), unparseable health file (`batches_unreadable: 1`).
