### PR TITLE
fix(recipes): retire the inert auto_approve key; prove document-generation's no-existing-document path live

### DIFF
--- a/recipes/document-generation.yaml
+++ b/recipes/document-generation.yaml
@@ -42,6 +42,31 @@
 #   amplifier run "execute document-generation-parallel.yaml with outline_path=./outline.json existing_document_path=./current-doc.md"
 #
 # =============================================================================
+# APPROVAL GATES (this recipe is staged and pauses FIVE times)
+# =============================================================================
+#
+# A gate is declared on each of these stages:
+#
+#   generation | validation-structural | validation-content
+#   validation-quality | finalization
+#
+# Each pause returns status "paused_for_approval" plus the run's session_id.
+# Continue with the engine's own operations -- from the SAME cwd, one gate at a
+# time (a fresh CLI process per call is fine):
+#
+#   amplifier tool invoke recipes operation=approve \
+#     session_id=<id> stage_name=<stage>
+#   amplifier tool invoke recipes operation=resume session_id=<id>
+#
+# There is NO `auto_approve` context key, and one cannot be added as a context
+# value: `approval.required` is a plain bool in the engine (ApprovalConfig in
+# tool-recipes/models.py) and is never template-expanded, so no context value
+# can make a gate conditional. This recipe DECLARED such a key until v8.4.0 and
+# nothing read it -- callers passing auto_approve: true still stopped at all
+# five gates. For a genuinely unattended run, keep a local copy of this file
+# whose stages set `approval.required: false`.
+#
+# =============================================================================
 # OUTLINE CONTRACT (what this recipe accepts as outline_path)
 # =============================================================================
 #
@@ -114,6 +139,38 @@
 # =============================================================================
 # CHANGELOG
 # =============================================================================
+#
+# v8.4.0 (2026-09-05):
+#   - HONESTY: removed the inert `auto_approve` context key (work item
+#     recipes-4ds). The key was declared and NOTHING read it: a caller passing
+#     auto_approve: true still stopped at all five of this recipe's gates, which
+#     is part of how gated v2 recipes came to look un-completable. It cannot be
+#     wired as declared either -- `approval.required` is a plain bool in the
+#     engine (ApprovalConfig in tool-recipes/models.py), never template-expanded,
+#     so no context value can make a gate conditional. Rather than invent a
+#     mechanism the shipped engine does not have, the key is GONE and the new
+#     "APPROVAL GATES" header block documents what actually works: execute, then
+#     `approve` + `resume` per gate from the same cwd (fresh CLI processes are
+#     fine), or a local copy with `approval.required: false`.
+#   - VERIFIED LIVE: the v8.3.0 no-existing-document fix (work item recipes-mxe)
+#     is now proven end to end rather than only reasoned about -- a full run with
+#     existing_document_path: "" generated one section per bfs_order entry and
+#     produced a non-empty v0_generated.md. See the PR body for the run record.
+#   - set-generation-complete-status' refusal now NAMES the outline's section
+#     count (structure.json .bfs_order) and the empty foreach, so the failure
+#     message points at the cause instead of only the symptom. It also warns
+#     (without failing) when generation completed with sections still pending.
+#   - BUGFIX (same class, carried across from the sibling recipe): the JSON
+#     helper this recipe writes in setup-json-helper shared outline-generation-
+#     from-doc's escape bug (work item recipes-cv1) -- clean_json_control_chars()
+#     assumed EVERY backslash inside a string began an escape sequence, so a
+#     literal backslash in the data (a shell line-continuation quoted verbatim
+#     out of a source document: backslash then a real newline) survived into
+#     json.loads and failed the payload with "Invalid \escape". A backslash pair
+#     is now copied through only when the next character is a valid JSON escape
+#     initiator ("\/bfnrt, or u + 4 hex digits).
+#   - Step count unchanged; no step ids added or removed. Still schema_version 2
+#     with the same dependency manifest.
 #
 # v8.3.0 (2026-09-02):
 #   - CONTRACT: accept outline-generation-from-document's output directly
@@ -413,7 +470,7 @@ dependencies:
 
 name: "document-generation"
 description: "Generate documentation from an outline with BFS traversal, parallel validation, provider preferences, and Design Intelligence feedback"
-version: "8.3.0"
+version: "8.4.0"
 author: "Amplifier Recipes Collection"
 tags: ["documentation", "generation", "outline", "bfs", "validation", "staged", "resumable", "parallel"]
 
@@ -427,8 +484,15 @@ context:
   # Optional: Working directory for state and versions
   working_dir: "./.docgen"
   
-  # Optional: Skip approval gates (for automated runs)
-  auto_approve: false
+  # NOTE: there is deliberately NO `auto_approve` key here. This recipe declared
+  # one until v8.4.0 and NOTHING read it -- a caller passing auto_approve: true
+  # still stopped at all five gates. It cannot be wired as declared, either:
+  # `approval.required` is a plain bool in the engine (ApprovalConfig in
+  # tool-recipes/models.py) and is not template-expanded, so no context value can
+  # make a gate conditional. To run this recipe unattended, drive it with the
+  # engine's own approval operations -- execute, then `approve` + `resume` per
+  # gate (see "APPROVAL GATES" in the header) -- or keep a local copy whose
+  # stages set `approval.required: false`.
   
   # Optional: Path to an existing document to use as reference
   # When provided, the recipe will:
@@ -500,9 +564,26 @@ stages:
                   
                   if in_string:
                       if c == '\\' and i + 1 < n:
-                          result.append(c)
-                          result.append(json_str[i + 1])
-                          i += 2
+                          # Only a VALID JSON escape may be copied through untouched
+                          # (v8.4.0, work item recipes-cv1). Assuming every backslash
+                          # starts one means a literal backslash in the data - most
+                          # commonly a shell line-continuation the LLM quoted verbatim,
+                          # backslash then a REAL newline - is emitted unchanged and
+                          # json.loads rejects the payload with "Invalid \escape".
+                          nxt = json_str[i + 1]
+                          is_valid_escape = nxt in '"\\/bfnrt' or (
+                              nxt == 'u'
+                              and re.match(r'[0-9a-fA-F]{4}', json_str[i + 2:i + 6] or '')
+                          )
+                          if is_valid_escape:
+                              result.append(c)
+                              result.append(nxt)
+                              i += 2
+                              continue
+                          # Literal backslash in the data - escape it and let the loop
+                          # handle the following character on its own terms.
+                          result.append('\\\\')
+                          i += 1
                           continue
                       elif c == '"':
                           j = i + 1
@@ -1722,6 +1803,7 @@ stages:
           set -euo pipefail
           
           tracker="{{working_dir}}/state/tracker.json"
+          structure="{{working_dir}}/state/structure.json"
           
           # GATE (v8.3.0): never stamp "generation_complete" over an empty
           # document. Before this gate the status was stamped unconditionally and
@@ -1730,18 +1812,29 @@ stages:
           completed=$(jq '.sections_completed | length' "$tracker")
           pending=$(jq '.sections_pending | length' "$tracker")
           generated=$(jq '.generated_content | length' "$tracker")
+          outline_sections=$(jq '.bfs_order // [] | length' "$structure")
           
           if [ "$generated" -eq 0 ]; then
             echo "ERROR: generation produced ZERO sections (generated_content is empty)" >&2
+            echo "       the outline asks for $outline_sections section(s) (structure.json .bfs_order)" >&2
             echo "       sections_completed=$completed sections_pending=$pending" >&2
-            echo "       generate-section's foreach ran zero times or no section persisted content." >&2
-            echo "       Inspect: $tracker and {{working_dir}}/state/structure.json (.bfs_order)" >&2
+            echo "       generate-section's foreach over llm_bfs_order ran ZERO times, or no" >&2
+            echo "       section persisted content. Refusing to stamp generation_complete over an" >&2
+            echo "       empty document - save-v0-generated would fail three steps later instead." >&2
+            echo "       Inspect: $tracker and $structure (.bfs_order)" >&2
             exit 1
           fi
           
           if [ "$completed" -eq 0 ] && [ "$pending" -gt 0 ]; then
             echo "ERROR: no sections completed but $pending still pending - refusing to stamp generation_complete" >&2
+            echo "       the outline asks for $outline_sections section(s); generated_content has $generated" >&2
             exit 1
+          fi
+          
+          if [ "$pending" -gt 0 ]; then
+            echo "WARNING: $pending of $outline_sections section(s) still pending after generation" >&2
+            echo "         (completed=$completed generated=$generated) - continuing, but the" >&2
+            echo "         assembled document will be missing those sections." >&2
           fi
           
           timestamp=$(date -Iseconds)

--- a/recipes/outline-generation-from-doc.yaml
+++ b/recipes/outline-generation-from-doc.yaml
@@ -87,13 +87,31 @@ dependencies:
 
 name: "outline-generation-from-document"
 description: "Generate structured outlines from existing documents with source identification, directionality detection, and classification"
-version: "1.8.0"
+version: "1.9.0"
 author: "Recipe Author Agent"
 tags: ["documentation", "outline", "analysis", "source-identification", "directionality", "authority-detection"]
 
 # =============================================================================
 # CHANGELOG
 # =============================================================================
+# v1.9.0 (2026-09-05):
+#   - BUGFIX: assemble-outline-structure hard-failed with "Invalid \\escape" on any
+#     LLM payload whose string values carried a LITERAL backslash -- most commonly
+#     a shell line-continuation (backslash then a real newline) quoted verbatim
+#     out of a source document (work item recipes-cv1, found while producing a
+#     live outline for recipes-mxe).
+#     * clean_json_control_chars() assumed EVERY backslash inside a string began
+#       an escape sequence and copied it plus the next character through
+#       untouched, so backslash+newline survived into json.loads and the literal
+#       newline never reached the branch that would have escaped it.
+#     * All three fallback extraction methods re-run that same cleaner, so they
+#       failed identically and the step died with "Could not parse flat_sections
+#       as JSON" after a full, expensive outline generation had already succeeded.
+#     * The cleaner now copies a backslash pair through ONLY when the next
+#       character is a valid JSON escape initiator ("\\/bfnrt, or u + 4 hex
+#       digits); any other backslash is escaped as data. `import re` added to the
+#       step's python heredoc for the hex-digit check.
+#
 # v1.8.0 (2026-09-02):
 #   - CONTRACT: documented this recipe's output as the agreed schema for
 #     document-generation.yaml (work item recipes-0sv). See "OUTPUT CONTRACT"
@@ -1775,6 +1793,7 @@ steps:
       # Use Python to assemble the nested structure from flat sections
       python3 << 'ASSEMBLE_EOF'
       import json
+      import re
       import sys
       
       # Parse the inputs - these come as JSON strings from previous steps
@@ -1807,10 +1826,29 @@ steps:
               if in_string:
                   # We're inside a quoted string
                   if c == '\\' and i + 1 < n:
-                      # Escape sequence - keep as-is and skip next char
-                      result.append(c)
-                      result.append(json_str[i + 1])
-                      i += 2
+                      # Only a VALID JSON escape may be copied through untouched.
+                      # Until v1.9.0 every backslash was assumed to start one, so a
+                      # literal backslash in the data - most commonly a shell
+                      # line-continuation the LLM quoted verbatim, backslash then a
+                      # REAL newline - was emitted unchanged and json.loads rejected
+                      # the whole payload with "Invalid \escape". The literal newline
+                      # never reached the branch below that would have escaped it,
+                      # and all three fallback extraction methods re-run this same
+                      # cleaner, so they failed identically. (work item recipes-cv1)
+                      nxt = json_str[i + 1]
+                      is_valid_escape = nxt in '"\\/bfnrt' or (
+                          nxt == 'u'
+                          and re.match(r'[0-9a-fA-F]{4}', json_str[i + 2:i + 6] or '')
+                      )
+                      if is_valid_escape:
+                          result.append(c)
+                          result.append(nxt)
+                          i += 2
+                          continue
+                      # Literal backslash in the data - escape it and let the loop
+                      # handle the following character on its own terms.
+                      result.append('\\\\')
+                      i += 1
                       continue
                   elif c == '"':
                       # Is this the end of the string, or an unescaped quote inside?


### PR DESCRIPTION
## Defects

Two tracked items, plus one found while proving them.

**recipes-4ds — `auto_approve` was inert.** `document-generation.yaml` declared
`auto_approve: false` in its context block and **no step or stage read it**. A caller
passing `auto_approve: true` still stopped at all five of the recipe's gates. This is
part of how gated schema-v2 recipes came to look un-completable.

**recipes-mxe — no-existing-document path generated ZERO sections.** With
`existing_document_path: ""`, `copy-preserved-sections` early-exited emitting
`sections_for_llm: []` while its own message said *"all sections need LLM
generation"*; `get-sections-for-llm` filtered `bfs_order` down to `[]`;
`generate-section`'s foreach ran zero times **silently**;
`set-generation-complete-status` stamped `generation_complete` unconditionally; and
the run died three steps later at `save-v0-generated` with *"Agent failed to write
v0_generated.md"* — the wrong step, the wrong message.

**recipes-cv1 — `Invalid \escape` (found while producing the live outline for the
above).** Both recipes' copies of `clean_json_control_chars()` assumed **every**
backslash inside a JSON string began an escape sequence.

## Root cause

| Defect | Location (this branch's line numbers) |
|---|---|
| recipes-4ds | `recipes/document-generation.yaml:431` on `main` (removed on this branch) — the key; `ApprovalConfig.required` is a plain `bool` in `tool-recipes/models.py:149`, never template-expanded, so the key was unwireable as declared |
| recipes-mxe | `recipes/document-generation.yaml:1518` (`copy-preserved-sections`), `:1654` (`get-sections-for-llm`), `:1800` (`set-generation-complete-status`) |
| recipes-cv1 | `recipes/outline-generation-from-doc.yaml:1828` and `recipes/document-generation.yaml:566` — `if c == '\\' and i + 1 < n: result.append(c); result.append(json_str[i+1]); i += 2` copies the pair through unconditionally, so backslash + **real newline** reaches `json.loads` and the literal newline never reaches the branch that would have escaped it |

The mxe *code* fix landed in v8.3.0 (aebfaa7) but had **never been run end to end** —
this PR is where it stops being a claim.

## Change

**`document-generation.yaml` 8.3.0 → 8.4.0**

- **Removed** the inert `auto_approve` key. Replaced with a comment saying why it is
  gone and cannot come back as a context value, plus a new **"APPROVAL GATES"** header
  block naming all five gated stages and the two things that actually work:
  `execute` → `approve` + `resume` per gate from the same cwd, or a local copy with
  `approval.required: false`. Honest option (a) from the item — no invented mechanism.
- `set-generation-complete-status`'s refusal now **names the outline's section count**
  (`structure.json .bfs_order`) and the empty foreach, and warns (without failing) if
  generation finished with sections still pending.
- Same escape fix as below in `setup-json-helper`.

**`outline-generation-from-doc.yaml` 1.8.0 → 1.9.0**

- A backslash pair is copied through **only** when the next character is a valid JSON
  escape initiator (`"\/bfnrt`, or `u` + 4 hex digits); any other backslash is escaped
  as data. `import re` added to the step's heredoc for the hex check.

No step ids added or removed in either recipe. Both stay `schema_version: 2` with
their dependency manifests unchanged.

## Gates

| Gate | Before (main) | After |
|---|---|---|
| `parse_manifest_file` | OK `schema_version=2` | OK `schema_version=2` |
| `plan()` closed-world, **no caller agents** | OK **steps=59** | OK **steps=59** |
| legacy `Recipe.from_yaml` + `validate_recipe` | VALID errors=0 warnings=0 | VALID errors=0 warnings=0 |
| outline recipe (same gates) | OK steps=28 / VALID | OK steps=28 / VALID |
| **TOTAL FAILURES** | **0** | **0** |

Legacy load parity is unchanged — same step count, same zero errors/warnings.
Artifacts: `gate-before-main.txt`, `gate-after.txt`.

**Escape-fix unit test** (`cleaner-unit-test.txt`) — the cleaner is extracted *from the
YAML itself* and run against 7 payload shapes, for **both** copies: backslash+newline
(the failure), Windows path, valid escapes preserved, `\uXXXX` preserved, trailing
valid backslash, literal newline, literal tab. **14/14 pass.**

**Fail-loud controls** (`guard-fail-loud-test.txt`) — `set-generation-complete-status`
run against the exact pre-fix tracker state from the recipes-mxe report:

```
NEGATIVE (bfs_order=3, generated_content={}) -> exit=1
  ERROR: generation produced ZERO sections (generated_content is empty)
         the outline asks for 3 section(s) (structure.json .bfs_order)
         sections_completed=0 sections_pending=3
         generate-section's foreach over llm_bfs_order ran ZERO times, or no
         section persisted content. Refusing to stamp generation_complete over an
         empty document - save-v0-generated would fail three steps later instead.
POSITIVE (3 sections generated)             -> exit=0
  Generation complete: 3 sections completed, 3 with content, 0 pending
```

## Live proof

All runs under `-b anchors-amp-dev`, `amplifier tool invoke recipes`.
Artifacts: `/home/bkrabach/dev/recipe-bundles-team-ci/dtu-artifacts/sweep/fix-mxe/`

**(a) `outline-generation-from-doc` → a real outline.** Target: a short prose doc
(`docs/RECIPES_VISION.md`) in a seeded local repo. Produced
`RECIPES_VISION_outline.json` — 6 sections (`PRODUCED-RECIPES_VISION_outline.json`).

Three earlier attempts failed and are kept as evidence, not hidden:
`live-outline-attempt1-FAILED.log` is the `Invalid \escape` defect fixed here;
attempts 2 and 3 hit the **second, unfixed** defect on recipes-cv1 (an unescaped inner
quote from a verbatim embedded JSON snippet the target doc contains at line 93). Both
report **CLI rc=0** while the tool result is an error. Attempt 4 used a prose-only
target and succeeded.

**(b) `document-generation`, `existing_document_path: ""`, gates driven for real.**
Gates were **approved and resumed** — no `required: false` copy was used. One
`execute` + five `approve` + five `resume`, each a **fresh CLI process from the same
cwd**, all on one `run_id`/`session_id`:

```
run_id         run-750caa7ca5ce
session_id     0b981581e33b4ba2-20260905-220743_recipe
execution_mode v2-closed-world-legacy-engine     schema_version 2
gates          generation -> validation-structural -> validation-content
               -> validation-quality -> finalization      (all approve rc=0)
final status   completed
```

Gate conditions, read back from disk after the run:

```
bfs_order                 : ['1','1.1','1.2','1.3','1.4','1.5']  (6 sections)
generated_content keys    : ['1','1.1','1.2','1.3','1.4','1.5']  (6)
one entry per bfs section : True
all entries non-empty     : True
sections_pending          : []
tracker status            : complete
versions/v0_generated.md  : exists=True bytes=1906
versions/v_final.md       : exists=True bytes=2013
output document           : exists=True bytes=2013
```

The engine's own step report agrees: `Generation complete: 6 sections completed, 6
with content, 0 pending`, with `status: success` for each of `1, 1.1, 1.2, 1.3, 1.4,
1.5` and `action_taken: generated_new`. Versions `v0 → v1 → v2 → v3 → v_final` all
present. Produced document: `PRODUCED-RECIPES_VISION-generated.md`.

## Not fixed here

`recipes-cv1` stays **open** for its second defect: `assemble-outline-structure` still
cannot parse an LLM payload whose string values contain a verbatim embedded JSON
snippet with unescaped inner quotes. The cleaner's lookahead heuristic (a `"` followed
by `:` ends the string) is structurally unable to disambiguate that case, and the
failure costs a full outline generation (~$0.86, ~13 min observed) before it surfaces.
Candidate directions are recorded on the item; none is attempted here.
