### PR TITLE
fix(recipes): ecosystem-activity-report reports "no activity" instead of dying on the zero-repos path (7vl)

### DIFF
--- a/recipes/ecosystem-activity-report.yaml
+++ b/recipes/ecosystem-activity-report.yaml
@@ -18,7 +18,7 @@ dependencies:
 
 name: "ecosystem-activity-report"
 description: "Analyze activity across the Amplifier ecosystem by discovering repos from MODULES.md"
-version: "1.17.0"
+version: "1.18.0"
 author: "Amplifier"
 tags: ["amplifier", "ecosystem", "github", "activity", "modules", "discovery"]
 
@@ -32,6 +32,35 @@ tags: ["amplifier", "ecosystem", "github", "activity", "modules", "discovery"]
 # 3. Reads MODULES.md to discover all ecosystem repos
 # 4. Filters repos based on criteria (org, name pattern)
 # 5. Calls the generic multi-repo recipe from @recipes bundle
+#
+# v1.18.0: the zero-repos path reports "no activity" instead of dying
+#         (work item recipes-7vl)
+#         - A repo_filter or date_range that selects repos with NO activity is
+#           an ordinary outcome, not an error. It used to be fatal: with
+#           analyses/ empty, set-final-validation's count was a bare
+#             ls -1 analyses/*-analysis.json 2>/dev/null | grep -v -E '...' | wc -l
+#           under `set -euo pipefail`. `ls` failed AND `grep -v` selected no
+#           lines (exit 1), so the pipeline aborted the step before it emitted
+#           anything at all. Its `on_error: continue` then wrote that EMPTY
+#           stdout into final_validation as a str, and assemble-report died two
+#           steps later on {{final_validation.still_missing}} with:
+#             "Cannot access 'still_missing' on {{final_validation}}
+#              - it's a str, not a dict"
+#           -- naming the symptom, two steps downstream of the producer.
+#         - Every leg of that count now tolerates the empty case, so the zero
+#           path runs to completion.
+#         - set-final-validation now validates its OWN output shape before
+#           emitting it, and fails naming ITSELF when the payload is not a JSON
+#           object. Its on_error is "fail" rather than "continue" for the same
+#           reason: silently substituting an unusable value for final_validation
+#           is what moved the failure away from the step that caused it.
+#         - assemble-report says so explicitly when zero repos had activity,
+#           rather than emitting a report shaped like one that found activity
+#           and happens to have every number at zero. Its two LLM-supplied
+#           arrays are read with `// []` defaults, since an empty dataset is
+#           exactly when a model is most likely to omit those keys.
+#         - v1.17.0's deterministic save-analyses-to-file step is unchanged.
+#         - Unit-tested by tests/test_ecosystem_activity_final_validation.py.
 #
 # v1.17.0: save-analyses-to-file no longer uses a model as a file-copy primitive
 #         (work item recipes-zfl)
@@ -1113,29 +1142,66 @@ steps:
       
       # Recount (only main {repo}-analysis.json, not chunk/commit/pr intermediates)
       # v1.15.1: Filter out intermediate files from repo-activity-analysis v3.0.0+
-      expected=$(wc -l < expected-repos.txt | tr -d ' ')
-      analyzed=$(ls -1 analyses/*-analysis.json 2>/dev/null | grep -v -E '(-chunk-|-commit-|-pr-|-all-chunks|-deep-dives)' | wc -l | tr -d ' ')
+      #
+      # v1.18.0: every leg of this count tolerates the EMPTY case. It used to be
+      # one pipeline:
+      #   analyzed=$(ls -1 analyses/*-analysis.json 2>/dev/null | grep -v -E ... | wc -l)
+      # With analyses/ empty -- an ordinary outcome for a narrow repo_filter or a
+      # quiet window -- `ls` failed AND `grep -v` selected no lines (exit 1), so
+      # `set -o pipefail` aborted this step before it emitted anything, and its
+      # then-`on_error: continue` handed the consumer an empty STRING for
+      # final_validation. See the v1.18.0 note at the top of this file.
+      count_analyses() {
+        { ls -1 analyses/*-analysis.json 2>/dev/null || true; } \
+          | { grep -v -E '(-chunk-|-commit-|-pr-|-all-chunks|-deep-dives)' || true; }
+      }
+      
+      if [ -f expected-repos.txt ]; then
+        expected=$(grep -c . expected-repos.txt || true)
+      else
+        echo "WARNING: set-final-validation: expected-repos.txt is missing; treating expected as 0" >&2
+        expected=0
+      fi
+      analyzed=$(count_analyses | grep -c . || true)
       still_missing=$((expected - analyzed))
+      if [ "$still_missing" -lt 0 ]; then
+        still_missing=0
+      fi
       
       if [ "$still_missing" -eq 0 ]; then
-        echo '{"all_complete": true, "still_missing": 0, "repos": []}' 
+        if [ "$expected" -eq 0 ]; then
+          echo "Final validation: no repos had activity in this range; nothing to analyze" >&2
+        fi
+        payload='{"all_complete": true, "still_missing": 0, "repos": []}'
       else
         # Find missing repos
-        ls -1 analyses/*-analysis.json 2>/dev/null | \
-          grep -v -E '(-chunk-|-commit-|-pr-|-all-chunks|-deep-dives)' | \
-          xargs -I {} basename {} -analysis.json | sort > analyzed-repos-final.txt
+        count_analyses | xargs -I {} basename {} -analysis.json | sort > analyzed-repos-final.txt
         missing=$(comm -23 expected-repos.txt analyzed-repos-final.txt || true)
         echo "Final validation: $still_missing repos missing" >&2
-        echo "$missing" | grep -v '^$' | sed 's/^/  - /' >&2
+        printf '%s\n' "$missing" | grep -v '^$' | sed 's/^/  - /' >&2 || true
         
-        missing_json=$(echo "$missing" | grep -v '^$' | jq -R -s 'split("\n") | map(select(length > 0))')
-        jq -n --argjson m "$missing_json" --argjson c "$still_missing" \
-          '{"all_complete": false, "still_missing": $c, "repos": $m}'
+        missing_json=$(printf '%s\n' "$missing" | jq -R -s 'split("\n") | map(select(length > 0))')
+        payload=$(jq -n --argjson m "$missing_json" --argjson c "$still_missing" \
+          '{"all_complete": false, "still_missing": $c, "repos": $m}')
       fi
+      
+      # v1.18.0: validate this step's OWN output before emitting it. Every
+      # consumer indexes into final_validation (assemble-report reads
+      # .still_missing twice), so a payload that is not a JSON object has to
+      # fail HERE, naming THIS step, rather than surfacing two steps later as a
+      # type error against a variable whose producer the reader must then hunt.
+      if ! printf '%s' "$payload" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        echo "ERROR: step 'set-final-validation' produced output that is not a JSON object." >&2
+        echo "       Its output becomes final_validation, which assemble-report indexes" >&2
+        echo "       into (.still_missing); a non-object there is unusable downstream." >&2
+        echo "       produced: $payload" >&2
+        exit 1
+      fi
+      printf '%s\n' "$payload"
     output: "final_validation"
     parse_json: true
     timeout: 60
-    on_error: "continue"
+    on_error: "fail"
 
   # ==========================================================================
   # Step 10a: Calculate report statistics (DETERMINISTIC)
@@ -1397,6 +1463,19 @@ steps:
 
       HEADEREOF
       
+      # v1.18.0: zero repos with activity is an ordinary outcome (a narrow
+      # repo_filter, a quiet window), not a failure. Say so plainly rather than
+      # emitting a report shaped like one that found activity and happens to
+      # have every number at zero.
+      repos_with_activity={{report_stats.totals.repos}}
+      if [ "$repos_with_activity" -eq 0 ]; then
+        {
+          printf '%s\n' ''
+          printf '%s\n' '> **No activity found.** No repository matched this scope with activity in this date range, so there is nothing to report for this window. Every repository checked is listed under "Repositories with No Activity" at the end of this report.'
+          printf '%s\n' ''
+        } >> final-report.md
+      fi
+      
       # v1.9.0: Add data gap warning if any repos failed analysis
       still_missing={{final_validation.still_missing}}
       if [ "$still_missing" -gt 0 ]; then
@@ -1411,7 +1490,10 @@ steps:
       echo "" >> final-report.md
       
       # Add key highlights from LLM
-      jq -r '.key_highlights[]' exec-summary.json | while read -r highlight; do
+      # v1.18.0: `// []` -- an empty dataset is exactly when a model is most
+      # likely to return an object without this key, and `.key_highlights[]` on
+      # a missing key aborts this step under `set -euo pipefail`.
+      jq -r '(.key_highlights // [])[]' exec-summary.json | while read -r highlight; do
         echo "- $highlight" >> final-report.md
       done
       
@@ -1430,6 +1512,13 @@ steps:
       ## Activity by Repository
 
       REPOHEADEREOF
+      
+      # v1.18.0: with no active repos the loop below writes nothing, leaving a
+      # bare heading. Say why it is empty.
+      if [ "$repos_with_activity" -eq 0 ]; then
+        printf '%s\n' '_No repository had activity in this date range._' >> final-report.md
+        printf '%s\n' '' >> final-report.md
+      fi
       
       # Add per-repo sections with injected stats
       jq -c '.[]' report-stats.json 2>/dev/null | head -1 > /dev/null || true
@@ -1470,9 +1559,16 @@ steps:
       echo "## Cross-Cutting Observations" >> final-report.md
       echo "" >> final-report.md
       
-      jq -r '.cross_cutting_observations[]' repo-sections.json | while read -r obs; do
+      # v1.18.0: `// []` for the same reason as key_highlights above, and count
+      # first -- with nothing to compare across repos the model legitimately
+      # returns [], which would otherwise leave a bare heading with no body.
+      obs_count=$(jq '(.cross_cutting_observations // []) | length' repo-sections.json)
+      jq -r '(.cross_cutting_observations // [])[]' repo-sections.json | while read -r obs; do
         echo "- $obs" >> final-report.md
       done
+      if [ "$obs_count" -eq 0 ]; then
+        printf '%s\n' '_None reported._' >> final-report.md
+      fi
       
       # v1.9.0: Add Failed Analyses section if any repos still missing after retry
       still_missing={{final_validation.still_missing}}

--- a/tests/test_ecosystem_activity_final_validation.py
+++ b/tests/test_ecosystem_activity_final_validation.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Unit tests for set-final-validation in recipes/ecosystem-activity-report.yaml.
+
+Work item recipes-7vl.
+
+The step's `command:` is read out of the recipe, substituted exactly as the
+recipe engine substitutes it, and run under real bash against a synthetic
+working directory. No model, no network.
+
+The case that mattered: a repo_filter or date_range that selects repos with NO
+activity leaves analyses/ empty. The step used to abort under
+`set -euo pipefail` before emitting anything, and its `on_error: continue` then
+handed assemble-report an empty STRING for final_validation -- which failed two
+steps later as "it's a str, not a dict", naming the symptom rather than this
+step.
+
+Run:  python3 tests/test_ecosystem_activity_final_validation.py
+Exits 0 when every case passes, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RECIPE = REPO_ROOT / "recipes" / "ecosystem-activity-report.yaml"
+STEP_ID = "set-final-validation"
+CONSUMER_ID = "assemble-report"
+
+FAILURES: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    print(f"  {'PASS' if ok else 'FAIL'}  {name}")
+    if not ok:
+        if detail:
+            print(f"          {detail}")
+        FAILURES.append(name)
+
+
+def get_step(step_id: str) -> dict:
+    recipe = yaml.safe_load(RECIPE.read_text())
+    for step in recipe["steps"]:
+        if step.get("id") == step_id:
+            return step
+    raise AssertionError(f"step {step_id!r} not found in {RECIPE}")
+
+
+def render(command: str, working_dir: Path) -> str:
+    return command.replace("{{working_dir}}", str(working_dir))
+
+
+def run(command: str, working_dir: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", render(command, working_dir)],
+        capture_output=True,
+        text=True,
+        cwd=str(working_dir),
+    )
+
+
+def make_working_dir(
+    root: Path,
+    expected: list[str] | None,
+    analyzed: list[str],
+    make_analyses_dir: bool = True,
+) -> Path:
+    """Build the on-disk state set-final-validation reads.
+
+    expected=None means expected-repos.txt is absent entirely.
+    """
+    if expected is not None:
+        (root / "expected-repos.txt").write_text(
+            "".join(f"{r}\n" for r in sorted(expected)), encoding="utf-8"
+        )
+    if make_analyses_dir:
+        analyses = root / "analyses"
+        analyses.mkdir(parents=True, exist_ok=True)
+        for repo in analyzed:
+            (analyses / f"{repo}-analysis.json").write_text(
+                json.dumps({"repo": repo}), encoding="utf-8"
+            )
+        # intermediates the count must NOT credit as analysed repos
+        for name in (
+            "ghost-chunk-1-analysis.json",
+            "ghost-commit-analysis.json",
+            "ghost-pr-analysis.json",
+        ):
+            (analyses / name).write_text(json.dumps({"intermediate": True}), encoding="utf-8")
+    return root
+
+
+def parsed_stdout(proc: subprocess.CompletedProcess):
+    try:
+        return json.loads(proc.stdout.strip())
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def test_zero_repos_path(command: str) -> None:
+    print("\n=== the zero-repos path completes and emits a JSON object ===")
+
+    # analyses/ exists but is empty -- the exact state recipes-7vl observed
+    with tempfile.TemporaryDirectory() as tmp:
+        wd = make_working_dir(Path(tmp), expected=[], analyzed=[])
+        proc = run(command, wd)
+        obj = parsed_stdout(proc)
+        check(
+            "empty analyses/ + empty expected-repos.txt exits 0",
+            proc.returncode == 0,
+            f"rc={proc.returncode} stderr={proc.stderr.strip()[:400]}",
+        )
+        check(
+            "emits a JSON OBJECT (not the empty string that became a str)",
+            isinstance(obj, dict),
+            f"stdout={proc.stdout!r}",
+        )
+        check(
+            "reports still_missing 0 / all_complete true",
+            isinstance(obj, dict)
+            and obj.get("still_missing") == 0
+            and obj.get("all_complete") is True,
+            f"obj={obj!r}",
+        )
+
+    # analyses/ never created at all (no repo analysis ever ran)
+    with tempfile.TemporaryDirectory() as tmp:
+        wd = make_working_dir(Path(tmp), expected=[], analyzed=[], make_analyses_dir=False)
+        proc = run(command, wd)
+        obj = parsed_stdout(proc)
+        check(
+            "missing analyses/ directory exits 0 with an object",
+            proc.returncode == 0 and isinstance(obj, dict) and obj.get("still_missing") == 0,
+            f"rc={proc.returncode} stdout={proc.stdout!r} stderr={proc.stderr.strip()[:400]}",
+        )
+
+
+def test_missing_expected_file(command: str) -> None:
+    print("\n=== a missing expected-repos.txt warns, it does not abort ===")
+    with tempfile.TemporaryDirectory() as tmp:
+        wd = make_working_dir(Path(tmp), expected=None, analyzed=[])
+        proc = run(command, wd)
+        obj = parsed_stdout(proc)
+        check(
+            "exits 0 with a JSON object",
+            proc.returncode == 0 and isinstance(obj, dict),
+            f"rc={proc.returncode} stdout={proc.stdout!r} stderr={proc.stderr.strip()[:400]}",
+        )
+        check(
+            "says on stderr that expected-repos.txt was missing",
+            "expected-repos.txt is missing" in proc.stderr,
+            f"stderr={proc.stderr.strip()[:400]}",
+        )
+
+
+def test_happy_and_missing_repo_paths(command: str) -> None:
+    print("\n=== the populated paths still count what they always counted ===")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        wd = make_working_dir(Path(tmp), expected=["a", "b"], analyzed=["a", "b"])
+        proc = run(command, wd)
+        obj = parsed_stdout(proc)
+        check(
+            "all repos analysed -> all_complete true, still_missing 0",
+            proc.returncode == 0
+            and isinstance(obj, dict)
+            and obj.get("all_complete") is True
+            and obj.get("still_missing") == 0,
+            f"rc={proc.returncode} obj={obj!r} stderr={proc.stderr.strip()[:400]}",
+        )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        wd = make_working_dir(Path(tmp), expected=["a", "b", "c"], analyzed=["a", "c"])
+        proc = run(command, wd)
+        obj = parsed_stdout(proc)
+        check(
+            "one repo missing -> all_complete false, still_missing 1",
+            proc.returncode == 0
+            and isinstance(obj, dict)
+            and obj.get("all_complete") is False
+            and obj.get("still_missing") == 1,
+            f"rc={proc.returncode} obj={obj!r} stderr={proc.stderr.strip()[:400]}",
+        )
+        check(
+            "names the missing repo",
+            isinstance(obj, dict) and obj.get("repos") == ["b"],
+            f"obj={obj!r}",
+        )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        wd = make_working_dir(Path(tmp), expected=["a"], analyzed=["a"])
+        proc = run(command, wd)
+        obj = parsed_stdout(proc)
+        check(
+            "chunk/commit/pr intermediates are not counted as analysed repos",
+            proc.returncode == 0 and isinstance(obj, dict) and obj.get("still_missing") == 0,
+            f"rc={proc.returncode} obj={obj!r}",
+        )
+
+
+def test_self_validating_shape_guard(command: str) -> None:
+    print("\n=== the step validates its OWN output and fails naming ITSELF ===")
+
+    marker = "if ! printf '%s' \"$payload\" | jq -e 'type == \"object\"'"
+    check("the shape guard is present in the step", marker in command, "guard not found")
+    if marker not in command:
+        return
+
+    head, _, tail = command.partition(marker)
+    for label, bad_payload in (
+        ("a bare string", '"just a string"'),
+        ("an array", "[]"),
+        ("unparseable text", "not json at all"),
+    ):
+        # Run the step's REAL guard code, with the payload forced to a
+        # non-object right before it. Everything up to the guard is the step's
+        # own text, unmodified.
+        injected = f"{head}payload='{bad_payload}'\n      {marker}{tail}"
+        with tempfile.TemporaryDirectory() as tmp:
+            wd = make_working_dir(Path(tmp), expected=[], analyzed=[])
+            proc = run(injected, wd)
+            check(
+                f"{label} -> non-zero exit",
+                proc.returncode != 0,
+                f"rc={proc.returncode} stdout={proc.stdout!r}",
+            )
+            check(
+                f"{label} -> stderr names 'set-final-validation'",
+                "set-final-validation" in proc.stderr,
+                f"stderr={proc.stderr.strip()[:400]}",
+            )
+            check(
+                f"{label} -> stderr says it is not a JSON object",
+                "not a JSON object" in proc.stderr,
+                f"stderr={proc.stderr.strip()[:400]}",
+            )
+            check(
+                f"{label} -> emits nothing on stdout",
+                proc.stdout.strip() == "",
+                f"stdout={proc.stdout!r}",
+            )
+
+
+def test_step_declarations(step: dict) -> None:
+    print("\n=== the step's declarations keep the failure attached to it ===")
+    check("step is a bash step", step.get("type") == "bash", f"type={step.get('type')!r}")
+    check("parse_json is set", step.get("parse_json") is True, f"parse_json={step.get('parse_json')!r}")
+    check(
+        "on_error is 'fail' -- 'continue' is what substituted an unusable value",
+        step.get("on_error") == "fail",
+        f"on_error={step.get('on_error')!r}",
+    )
+
+
+def test_consumer_zero_activity_report(consumer: dict) -> None:
+    print("\n=== the consumer reports 'no activity' rather than a hollow report ===")
+    command = consumer["command"]
+    check(
+        "assemble-report still reads final_validation.still_missing",
+        "{{final_validation.still_missing}}" in command,
+        "the consumer this step feeds no longer indexes into final_validation",
+    )
+    check(
+        "writes an explicit no-activity note when zero repos had activity",
+        "No activity found." in command and "repos_with_activity" in command,
+        "no zero-activity branch found in assemble-report",
+    )
+    check(
+        "key_highlights is read with a // [] default",
+        "(.key_highlights // [])[]" in command,
+        "an LLM object without key_highlights would abort assemble-report",
+    )
+    check(
+        "cross_cutting_observations is read with a // [] default",
+        "(.cross_cutting_observations // [])[]" in command,
+        "an LLM object without cross_cutting_observations would abort assemble-report",
+    )
+
+
+def main() -> int:
+    print(f"Testing {STEP_ID} in {RECIPE.relative_to(REPO_ROOT)}")
+    step = get_step(STEP_ID)
+    command = step["command"]
+
+    test_step_declarations(step)
+    test_zero_repos_path(command)
+    test_missing_expected_file(command)
+    test_happy_and_missing_repo_paths(command)
+    test_self_validating_shape_guard(command)
+    test_consumer_zero_activity_report(get_step(CONSUMER_ID))
+
+    print()
+    if FAILURES:
+        print(f"FAILED: {len(FAILURES)} check(s)")
+        for name in FAILURES:
+            print(f"  - {name}")
+        return 1
+    print("All checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Defect

`recipes/ecosystem-activity-report.yaml` died whenever the repo_filter / date_range
selected repos with **zero activity** — an ordinary outcome for a narrow filter or a
quiet window. Observed on `origin/main` while producing the live proof for recipes-zfl
(log: `dtu-artifacts/sweep/am-content/zfl-ecosystem.log`):

```
Cannot access 'still_missing' on {{final_validation}} - it's a str, not a dict.
Hint: The step producing 'final_validation' may have failed to parse JSON.
```

Every upstream step behaved correctly on the empty set (`expected-repos.txt` 0 bytes,
`analyses/` empty, `reduced-analyses.json` `[]`). The failure named the **symptom**, two
steps downstream of the step that caused it.

## Root cause

`recipes/ecosystem-activity-report.yaml:1117` (pre-change), inside step
`set-final-validation`:

```bash
analyzed=$(ls -1 analyses/*-analysis.json 2>/dev/null \
  | grep -v -E '(-chunk-|-commit-|-pr-|-all-chunks|-deep-dives)' | wc -l | tr -d ' ')
```

The step runs under `set -euo pipefail`. With `analyses/` empty, `ls` failed **and**
`grep -v` selected no lines (exit 1), so `pipefail` + `errexit` aborted the step **before
it emitted anything**. Reproduced deterministically against `HEAD`:

```
OLD STEP on zero-repos path: rc=1  stdout=''  stderr=''
```

The step's `on_error: "continue"` then stored that empty stdout as `final_validation`
(`parse_json` cannot parse `""`, so it stays a `str`), and `assemble-report` —
which reads `{{final_validation.still_missing}}` twice — raised the type error above.

## Change (recipe v1.17.0 → v1.18.0)

1. **`set-final-validation` survives the empty set.** Every leg of the count tolerates
   zero files (`{ ls … || true; } | { grep -v … || true; }`), and a missing
   `expected-repos.txt` warns instead of aborting.
2. **The producer validates its own output shape.** The payload is built into a variable
   and checked with `jq -e 'type == "object"'` before emission; a non-object exits 1 with
   stderr naming **`set-final-validation`** itself and what it produced. Its `on_error` is
   now `"fail"` rather than `"continue"` — silently substituting an unusable value for
   `final_validation` is exactly what moved the failure away from the step that caused it.
3. **The report says "no activity".** `assemble-report` emits an explicit
   `> **No activity found.**` note when zero repos had activity, and fills the two
   sections that would otherwise be bare headings. Its two LLM-supplied arrays are read
   with `// []` defaults — an empty dataset is precisely when a model omits those keys,
   and `.key_highlights[]` on a missing key would abort the step under `set -euo pipefail`.
4. **#396's deterministic `save-analyses-to-file` step is unchanged.** `schema_version: 2`
   and the `dependencies:` manifest are intact. Version + changelog bumped.
5. **New unit test** `tests/test_ecosystem_activity_final_validation.py` — reads the step's
   `command:` out of the recipe, substitutes as the engine does, runs it under real bash.
   28 checks, no model, no network. The shape guard is exercised by running the step's
   **own** guard text with the payload forced to a string / an array / unparseable text.

## Gates

| Gate | Result |
|---|---|
| `python -m amplifier_recipe_runner validate recipes/ecosystem-activity-report.yaml` | `status: ok`, `schema_version: 2`, rc=0 |
| Legacy load parity (`tool-recipes` `Recipe.from_yaml` + `validate_recipe`) | **11 errors before → 11 errors after**, identical set (the known pre-existing template errors); warnings 1 → 1 |
| `tests/test_ecosystem_activity_final_validation.py` (new) | 28/28 PASS |
| `tests/test_ecosystem_activity_save_analyses.py` (#396's) | PASS, TOTAL FAILURES: 0 |

## Live proof

Both runs: `amplifier tool invoke recipes -b anchors-amp-dev operation=execute` against this
branch's recipe. Logs under `dtu-artifacts/sweep/am-7vl/`.

**(a) zero-activity filter** — `{"date_range":"since 2099-01-01","org_filter":"microsoft","repo_filter":"amplifier-bundle-notify","parallel_analysis":1}`
(`7vl-zero.log`, rc=0, 29s):

- `'status': 'completed'`
- `'active_repos': {'count': 0, …, 'skipped': ['amplifier-bundle-notify'], 'skipped_count': 1}`
- `'final_validation': {'all_complete': True, 'still_missing': 0, 'repos': []}` — a **dict**, not a str
- report written (1.6 KB), containing:

```
> **No activity found.** No repository matched this scope with activity in this date
range, so there is nothing to report for this window. …

## Activity by Repository

_No repository had activity in this date range._

## Cross-Cutting Observations

_None reported._

## Repositories with No Activity

- amplifier-bundle-notify
```

**(b) real small filter** — `{"date_range":"since 2026-09-01","org_filter":"microsoft","repo_filter":"amplifier-bundle-notify","parallel_analysis":1}`
(`7vl-real.log`, rc=0, 65s):

- `'status': 'completed'`
- `'active_repos': {'count': 1, 'repos': [{… 'amplifier-bundle-notify' …, 'commits': 0, 'prs': 1}], 'skipped_count': 0}`
- `'final_validation': {'all_complete': True, 'still_missing': 0, 'repos': []}`
- report written (2.9 KB) with a real per-repo section, highlights, risks and 2 cross-cutting
  observations; the no-activity note is **absent** (0 occurrences), as it should be.

Work item: `recipes-7vl`.
